### PR TITLE
Silence debconf frontend warnings in CI

### DIFF
--- a/.github/workflows/build-packages-gh.yml
+++ b/.github/workflows/build-packages-gh.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-deb:
     runs-on: ubuntu-latest
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TERM: xterm-256color
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- set noninteractive debconf frontend in the questing build job
- define a TERM to avoid debconf frontend initialization warnings

Closes #2.

## Testing
Not run (workflow-only change).