### PR TITLE
Suppress monet/neverthrow peer warnings in CI

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,3 +14,10 @@ rm .yarnrc.yml .yarn -rf
 yarn set version stable
 
 yarn config set nodeLinker node-modules
+
+cat >> .yarnrc.yml <<'YAML'
+peerDependencyRules:
+  ignoreMissing:
+    - monet
+    - neverthrow
+YAML


### PR DESCRIPTION
## Summary
- append Yarn peerDependencyRules to ignore missing `monet` and `neverthrow`
- keep change in bootstrap to avoid touching submodules

Closes #4.

## Testing
Not run (config-only change).