### PR TITLE
Fix CI failure from unsupported Yarn config

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,10 +14,3 @@ rm .yarnrc.yml .yarn -rf
 yarn set version stable
 
 yarn config set nodeLinker node-modules
-
-cat >> .yarnrc.yml <<'YAML'
-peerDependencyRules:
-  ignoreMissing:
-    - monet
-    - neverthrow
-YAML


### PR DESCRIPTION
## Summary
- remove unsupported `peerDependencyRules` from bootstrap-generated `.yarnrc.yml`

Closes #10.

## Testing
Not run yet (please run the Build Packages (GitHub) workflow).