### PR TITLE
Install Java and Graphviz for plantuml-pipe

### DIFF
--- a/.github/workflows/build-packages-gh.yml
+++ b/.github/workflows/build-packages-gh.yml
@@ -41,9 +41,11 @@ jobs:
           apt-get install -y --no-install-recommends \
             build-essential \
             debhelper-compat \
+            default-jre-headless \
             dh-python \
             dpkg-dev \
             fakeroot \
+            graphviz \
             jq \
             moreutils \
             python3 \


### PR DESCRIPTION
## Summary
- Install `default-jre-headless` and `graphviz` in the CI container.
- Silence the `plantuml-pipe` warning about missing Java/Graphviz.

## Testing
- Not run (please trigger the `Build Packages (GitHub)` workflow for this branch).