### PR TITLE
Document local AGENTS.md ignore (#45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,6 @@ node_modules/
 # Generated files
 src/version.js
 
-# Agent artifacts
+# Agent artifacts (local-only)
 AGENTS.md
 agent.md


### PR DESCRIPTION
Summary
- Clarify `.gitignore` entry for local `AGENTS.md` usage.

Notes
- `AGENTS.md` is intentionally untracked; created locally for Codex resume guidance.

Testing
- Not run (not applicable).