### PR TITLE
Issue C (#49): Replace custom Navigation with PF Tabs

### DIFF
--- a/zfs/src/components/common/Navigation.vue
+++ b/zfs/src/components/common/Navigation.vue
@@ -1,30 +1,30 @@
 <template>
-	<div class="bg-default">
-		<div>
-			<div class="border-b border-default">
-				<nav class="-mb-px flex justify-center" aria-label="Tabs">
-					<a v-for="item in props.navigationItems" :key="item.name"
-						@click.prevent="navigationCallback(item)"
-						:class="[item.current ? 'border-default text-default' : 'border-transparent text-secondary hover:border-default hover:text-default', 'whitespace-nowrap border-b-4 py-4 px-4 text-sm font-medium']" :aria-current="item.current ? 'page' : undefined">{{ item.name }}</a>
-					
-					
-
-
-				</nav>
-			</div>
-		</div>
-
-	
+	<div class="pf-v5-c-tabs">
+		<ul class="pf-v5-c-tabs__list" role="tablist">
+			<li
+				v-for="(item, idx) in navItems"
+				:key="item.name"
+				class="pf-v5-c-tabs__item"
+				:class="{ 'pf-m-current': item.current }"
+			>
+				<button
+					ref="tabRefs"
+					class="pf-v5-c-tabs__link"
+					role="tab"
+					:aria-selected="item.current"
+					:tabindex="item.current ? 0 : -1"
+					@click="navigationCallback(item)"
+					@keydown="onKeydown($event, idx)"
+				>
+					<span class="pf-v5-c-tabs__item-text">{{ item.name }}</span>
+				</button>
+			</li>
+		</ul>
 	</div>
 </template>
-<style>
-/* CSS to disable page scrolling */
-.no-scroll {
-  overflow: hidden;
-  height: 100vh;
-}
-</style>
+
 <script setup lang="ts">
+import { computed, ref } from 'vue';
 import { NavigationItem, NavigationCallback } from '../../types';
 
 interface NavigationProps {
@@ -34,11 +34,38 @@ interface NavigationProps {
 	navigationCallback: NavigationCallback;
 }
 
-// onMounted(() => {
-//   notificationStore.fetchMissedNotifications();
-//   console.log("hello from navigation notification")
-// });
-
 const props = defineProps<NavigationProps>();
 
+const navItems = computed(() => props.navigationItems);
+
+const tabRefs = ref<HTMLButtonElement[]>([]);
+
+function focusTab(index: number) {
+	tabRefs.value[index]?.focus();
+}
+
+function onKeydown(event: KeyboardEvent, currentIndex: number) {
+	const count = navItems.value.length;
+	let targetIndex: number | null = null;
+
+	switch (event.key) {
+		case 'ArrowRight':
+			targetIndex = (currentIndex + 1) % count;
+			break;
+		case 'ArrowLeft':
+			targetIndex = (currentIndex - 1 + count) % count;
+			break;
+		case 'Home':
+			targetIndex = 0;
+			break;
+		case 'End':
+			targetIndex = count - 1;
+			break;
+		default:
+			return;
+	}
+
+	event.preventDefault();
+	focusTab(targetIndex);
+}
 </script>

--- a/zfs/src/components/common/Navigation.vue
+++ b/zfs/src/components/common/Navigation.vue
@@ -1,8 +1,8 @@
 <template>
-	<div class="pf-v5-c-tabs">
+	<div v-if="show" class="pf-v5-c-tabs">
 		<ul class="pf-v5-c-tabs__list" role="tablist">
 			<li
-				v-for="(item, idx) in navItems"
+				v-for="(item, idx) in props.navigationItems"
 				:key="item.name"
 				class="pf-v5-c-tabs__item"
 				:class="{ 'pf-m-current': item.current }"
@@ -11,6 +11,8 @@
 					ref="tabRefs"
 					class="pf-v5-c-tabs__link"
 					role="tab"
+					:id="'pf-tab-' + item.tag"
+					:aria-controls="'pf-tab-panel-' + item.tag"
 					:aria-selected="item.current"
 					:tabindex="item.current ? 0 : -1"
 					@click="navigationCallback(item)"
@@ -24,7 +26,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import { NavigationItem, NavigationCallback } from '../../types';
 
 interface NavigationProps {
@@ -36,8 +38,6 @@ interface NavigationProps {
 
 const props = defineProps<NavigationProps>();
 
-const navItems = computed(() => props.navigationItems);
-
 const tabRefs = ref<HTMLButtonElement[]>([]);
 
 function focusTab(index: number) {
@@ -45,7 +45,8 @@ function focusTab(index: number) {
 }
 
 function onKeydown(event: KeyboardEvent, currentIndex: number) {
-	const count = navItems.value.length;
+	const count = props.navigationItems.length;
+	if (count === 0) return;
 	let targetIndex: number | null = null;
 
 	switch (event.key) {
@@ -67,5 +68,6 @@ function onKeydown(event: KeyboardEvent, currentIndex: number) {
 
 	event.preventDefault();
 	focusTab(targetIndex);
+	props.navigationCallback(props.navigationItems[targetIndex]);
 }
 </script>


### PR DESCRIPTION
## Summary

- Replace custom Navigation markup with PF5 Tabs (`pf-v5-c-tabs`)
- Switch from `<a>` to `<button>` for in-page tab switches
- Add ARIA: `role=tablist/tab`, `aria-selected`, `tabindex` management
- Implement keyboard navigation (ArrowLeft/Right, Home, End with wrapping)
- Remove Tailwind classes replaced by PF tab styling

Closes #49

## Test plan

- [ ] Tabs render with PF styling
- [ ] Click switches tabs correctly
- [ ] Arrow keys navigate between tabs
- [ ] Home/End go to first/last tab
- [ ] Active tab has visible focus indicator
- [ ] `aria-selected` updates correctly
- [ ] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)