### PR TITLE
Issue D (#50): Pools page — semantic PF tables, expandable rows, modals

### DIFF
--- a/zfs/src/components/dashboard/DashPoolCard.vue
+++ b/zfs/src/components/dashboard/DashPoolCard.vue
@@ -15,100 +15,7 @@
 							<span class="text-orange-700 ml-1">Upgrade Available</span>
 						</div>
 					</div>
-					<Menu as="div" class="relative inline-block text-right">
-						<div>
-							<MenuButton class="rounded-full p-1 bg-default text-default hover:text-gray-600">
-								<span class="sr-only">Open options</span>
-								<EllipsisVerticalIcon class="w-5" aria-hidden="true" />
-							</MenuButton>
-						</div>
-						<transition enter-active-class="transition ease-out duration-100"
-							enter-from-class="transform opacity-0 scale-95"
-							enter-to-class="transform opacity-100 scale-100"
-							leave-active-class="transition ease-in duration-75"
-							leave-from-class="transform opacity-100 scale-100"
-							leave-to-class="transform opacity-0 scale-95">
-							<MenuItems
-								class="absolute right-0 z-10 -mt-1 w-max origin-top-left rounded-md bg-accent shadow-lg">
-								<div class="py-1">
-									<MenuItem as="div" v-slot="{ active }">
-									<a href="#" @click="showDetails(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Pool
-										Details</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-									<a href="#" @click="clearPoolErrors(props.pool.name)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Clear
-										Pool Errors</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-									<a v-if="upgradeablePool" href="#" @click="upgradeThisPool(props.pool)!"
-										:class="[active ? 'bg-orange-700 text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Upgrade
-										Pool</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-									<a v-if="!scanActivity!.isActive" href="#" @click="resilverThisPool(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Resilver
-										Pool</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-									<a v-if="!scanActivity!.isActive" href="#" @click="scrubThisPool(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Scrub
-										Pool</a>
-									<a v-if="scanActivity!.isActive && scanActivity!.isPaused && scanOperation == 'SCRUB'"
-										href="#" @click="resumeScrub(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Resume
-										Scrub</a>
-									<a v-if="scanActivity!.isActive && !scanActivity!.isPaused && scanOperation == 'SCRUB'"
-										href="#" @click="pauseScrub(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Pause
-										Scrub</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-									<a v-if="scanActivity!.isActive && scanOperation == 'SCRUB'" href="#"
-										@click="stopScrub(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Cancel
-										Scrub</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-									<a v-if="!trimActivity!.isActive && !trimActivity!.isPaused && pool.diskType != 'HDD' && getIsTrimmable()"
-										href="#" @click="trimThisPool(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">TRIM
-										Pool</a>
-									<a v-if="trimActivity!.isPaused && pool.diskType != 'HDD' && getIsTrimmable()"
-										href="#" @click="resumeTrim(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Resume
-										TRIM (Pool)</a>
-									<a v-if="trimActivity!.isActive && pool.diskType != 'HDD' && getIsTrimmable()"
-										href="#" @click="pauseTrim(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Pause
-										TRIM (Pool)</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-									<a v-if="trimActivity!.isActive || trimActivity!.isPaused && pool.diskType != 'HDD' && getIsTrimmable()"
-										href="#" @click="stopTrim(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Cancel
-										TRIM (Pool)</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-									<a href="#" @click="showAddVDev(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Add
-										Virtual Device</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-									<a href="#" @click="exportThisPool(props.pool)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Export
-										Pool</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-									<a href="#" @click="destroyPoolAndUpdate(props.pool)!"
-										:class="[active ? 'bg-danger text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Destroy
-										Pool</a>
-									</MenuItem>
-								</div>
-							</MenuItems>
-						</transition>
-					</Menu>
+					<PfDropdownMenu :items="dashPoolMenuItems" :kebab="true" />
 				</div>
 				<div class="flex flex-row justify-between">
 					<div>
@@ -265,8 +172,9 @@
 
 <script setup lang="ts">
 import { ref, inject, Ref, computed, provide, watch, onMounted} from "vue";
-import { EllipsisVerticalIcon, CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/vue/24/outline';
-import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue';
+import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/vue/24/outline';
+import PfDropdownMenu from "../pf/PfDropdownMenu.vue";
+import type { DropdownMenuItem } from "../pf/PfDropdownMenu.vue";
 import { destroyPool, trimPool, scrubPool, resilverPool, clearErrors, exportPool, upgradePool } from "../../composables/pools";
 import { labelClear } from "../../composables/disks";
 import { formatStatus, isPoolUpgradable, getCapacityColor } from '../../composables/helpers'
@@ -336,6 +244,57 @@ function getIsTrimmable() {
 onMounted(() => {
 	getIsTrimmable();
 	canUpgradePool(props.pool.name);
+});
+
+// Computed menu items for PfDropdownMenu (replaces HeadlessUI Menu)
+const dashPoolMenuItems = computed<DropdownMenuItem[]>(() => {
+	const items: DropdownMenuItem[] = [
+		{ label: 'Pool Details', action: () => showDetails(props.pool) },
+	];
+
+	if (canDestructive.value) {
+		items.push({ label: 'Clear Pool Errors', action: () => clearPoolErrors(props.pool.name) });
+
+		if (upgradeablePool.value) {
+			items.push({ label: 'Upgrade Pool', action: () => upgradeThisPool(props.pool) });
+		}
+
+		if (!scanActivity.value?.isActive) {
+			items.push({ label: 'Resilver Pool', action: () => resilverThisPool(props.pool) });
+		}
+
+		if (!scanActivity.value?.isActive) {
+			items.push({ label: 'Scrub Pool', action: () => scrubThisPool(props.pool) });
+		}
+		if (scanActivity.value?.isActive && scanActivity.value?.isPaused && scanOperation.value == 'SCRUB') {
+			items.push({ label: 'Resume Scrub', action: () => resumeScrub(props.pool) });
+		}
+		if (scanActivity.value?.isActive && !scanActivity.value?.isPaused && scanOperation.value == 'SCRUB') {
+			items.push({ label: 'Pause Scrub', action: () => pauseScrub(props.pool) });
+		}
+		if (scanActivity.value?.isActive && scanOperation.value == 'SCRUB') {
+			items.push({ label: 'Cancel Scrub', action: () => stopScrub(props.pool) });
+		}
+
+		if (!trimActivity.value?.isActive && !trimActivity.value?.isPaused && props.pool.diskType != 'HDD' && getIsTrimmable()) {
+			items.push({ label: 'TRIM Pool', action: () => trimThisPool(props.pool) });
+		}
+		if (trimActivity.value?.isPaused && props.pool.diskType != 'HDD' && getIsTrimmable()) {
+			items.push({ label: 'Resume TRIM (Pool)', action: () => resumeTrim(props.pool) });
+		}
+		if (trimActivity.value?.isActive && props.pool.diskType != 'HDD' && getIsTrimmable()) {
+			items.push({ label: 'Pause TRIM (Pool)', action: () => pauseTrim(props.pool) });
+		}
+		if ((trimActivity.value?.isActive || trimActivity.value?.isPaused) && props.pool.diskType != 'HDD' && getIsTrimmable()) {
+			items.push({ label: 'Cancel TRIM (Pool)', action: () => stopTrim(props.pool) });
+		}
+
+		items.push({ label: 'Add Virtual Device', action: () => showAddVDev(props.pool) });
+		items.push({ label: 'Export Pool', action: () => exportThisPool(props.pool) });
+		items.push({ label: 'Destroy Pool', action: () => destroyPoolAndUpdate(props.pool) });
+	}
+
+	return items;
 });
 
 ///////// Values for Confirmation Modals ////////////

--- a/zfs/src/components/dashboard/Dashboard.vue
+++ b/zfs/src/components/dashboard/Dashboard.vue
@@ -13,7 +13,7 @@
 					<h6 class="mt-2"> Total Effective Space: {{ totalEffectivePoolSpace }} </h6>
 				</div>
 				<div class="p-2 flex justify-end">
-					<button class="btn btn-secondary" @click="refreshAllData">
+					<button class="pf-v5-c-button pf-m-plain" aria-label="Refresh pools" @click="refreshAllData">
 						<ArrowPathIcon class="h-5 w-5 m-1" aria-hidden="true"/>
 					</button>
 				</div>
@@ -30,7 +30,7 @@
 					<span class="font-semibold text-lg mt-1">No Pools Found</span>
 				</div>
 				<div class="p-2 flex justify-end col-start-3">
-					<button class="btn btn-primary" @click="refreshAllData">
+					<button class="pf-v5-c-button pf-m-plain" aria-label="Refresh pools" @click="refreshAllData">
 						<ArrowPathIcon class="h-5 w-5" aria-hidden="true"/>
 					</button>
 				</div>

--- a/zfs/src/components/disks/AttachDiskModal.vue
+++ b/zfs/src/components/disks/AttachDiskModal.vue
@@ -1,9 +1,5 @@
 <template>
-    <OldModal :isOpen="showFlag" @close="closeModal()" :marginTop="'mt-28'" :width="'w-3/5'" :minWidth="'min-w-3/5'" :closeOnBackgroundClick="false">
-        <template v-slot:title>
-            Attach Disk
-        </template>
-        <template v-slot:content>
+    <PfModal :isOpen="showFlag" title="Attach Disk" variant="large" @close="closeModal()">
             <div>
                 <!-- Disk ID (Select) -->
                 <div>
@@ -57,8 +53,8 @@
                 </div>
 
             </div>
-        </template>
-        <template v-slot:footer>
+
+        <template #footer>
             <div class="w-full grid grid-rows-2">
                 <div class="w-full row-start-1 justify-center items-center">
                     <div class="justify-self-start mt-2">
@@ -68,68 +64,33 @@
                 </div>
 
                 <div class="button-group-row w-full justify-between row-start-2">
-                    <div class="button-group-row mt-2">
+                    <div class="button-group-row mt-2 items-center">
                         <button @click="closeModal" :id="getIdKey('close-attach-disk-btn')" name="close-attach-disk-btn"
-                            class="btn btn-danger">Close</button>
+                            class="pf-v5-c-button pf-m-danger">Close</button>
 
-                        <div class="flex flex-row">
-                            <label :for="getIdKey('force-add-vdev')"
-                                class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Forcefully Attach
-                                Disk</label>
-                            <Switch v-model="diskVDevPoolData.forceAttach" :id="getIdKey('force-add-vdev')"
-                                :class="[diskVDevPoolData.forceAttach! ? 'bg-primary' : 'bg-accent', 'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                                <span class="sr-only">Use setting</span>
-                                <span
-                                    :class="[diskVDevPoolData.forceAttach! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                    <span
-                                        :class="[diskVDevPoolData.forceAttach! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                        aria-hidden="true">
-                                        <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                            <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-                                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                        </svg>
-                                    </span>
-                                    <span
-                                        :class="[diskVDevPoolData.forceAttach! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                        aria-hidden="true">
-                                        <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                            <path
-                                                d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                        </svg>
-                                    </span>
-                                </span>
-                            </Switch>
-                        </div>
+                        <PfSwitch v-model="diskVDevPoolData.forceAttach"
+                            :id="getIdKey('force-add-vdev')"
+                            label="Forcefully Attach Disk" />
                     </div>
                     <div class="button-group-row mt-2">
                         <button v-if="!adding" id="attach-disk-btn"
-                            class="btn btn-primary object-right justify-end mr-4 h-fit w-full"
+                            class="pf-v5-c-button pf-m-primary"
                             @click="attachDiskBtn">Attach Disk</button>
                         <button disabled v-if="adding" id="finish" type="button"
-                            class="btn btn-primary object-right justify-end">
-                            <svg aria-hidden="true" role="status"
-                                class="inline w-4 h-4 mr-3 text-gray-200 animate-spin text-default"
-                                viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path
-                                    d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-                                    fill="currentColor" />
-                                <path
-                                    d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-                                    fill="text-success" />
-                            </svg>
+                            class="pf-v5-c-button pf-m-primary pf-m-in-progress">
                             Attaching...
                         </button>
                     </div>
                 </div>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 </template>
 
 <script setup lang="ts">
 import { ref, inject, Ref, computed, onMounted } from 'vue';
-import { Switch } from '@headlessui/vue';
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
+import PfSwitch from '../pf/PfSwitch.vue';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
 import { convertSizeToBytes, getDiskIDName, truncateName } from '../../composables/helpers';
 import { attachDisk } from '../../composables/disks';

--- a/zfs/src/components/disks/ReplaceDiskModal.vue
+++ b/zfs/src/components/disks/ReplaceDiskModal.vue
@@ -1,9 +1,5 @@
 <template>
-    <OldModal :isOpen="showFlag" @close="closeModal()" :marginTop="'mt-28'" :width="'w-3/5'" :minWidth="'min-w-3/5'" :closeOnBackgroundClick="false">
-        <template v-slot:title>
-            Replace Disk
-        </template>
-        <template v-slot:content>
+    <PfModal :isOpen="showFlag" title="Replace Disk" variant="large" @close="closeModal()">
             <div>
                 <!-- Disk ID (Select) -->
                 <div>
@@ -57,8 +53,8 @@
                 </div>
 
             </div>
-        </template>
-        <template v-slot:footer>
+
+        <template #footer>
             <div class="w-full grid grid-rows-2">
                 <div class="w-full row-start-1 justify-center items-center">
                     <div class="justify-self-start mt-2">
@@ -68,67 +64,32 @@
                 </div>
 
                 <div class="button-group-row w-full justify-between row-start-2">
-                    <div class="button-group-row mt-2">
+                    <div class="button-group-row mt-2 items-center">
                         <button @click="closeModal" :id="getIdKey('close-replace-disk-btn')"
-                            name="close-replace-disk-btn" class="btn btn-danger">Close</button>
+                            name="close-replace-disk-btn" class="pf-v5-c-button pf-m-danger">Close</button>
 
-                        <div class="flex flex-row">
-                            <label :for="getIdKey('force-add-vdev')"
-                                class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Forcefully Replace
-                                Disk</label>
-                            <Switch v-model="diskVDevPoolData.forceReplace" :id="getIdKey('force-add-vdev')"
-                                :class="[diskVDevPoolData.forceReplace! ? 'bg-primary' : 'bg-accent', 'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                                <span class="sr-only">Use setting</span>
-                                <span
-                                    :class="[diskVDevPoolData.forceReplace! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                    <span
-                                        :class="[diskVDevPoolData.forceReplace! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                        aria-hidden="true">
-                                        <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                            <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-                                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                        </svg>
-                                    </span>
-                                    <span
-                                        :class="[diskVDevPoolData.forceReplace! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                        aria-hidden="true">
-                                        <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                            <path
-                                                d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                        </svg>
-                                    </span>
-                                </span>
-                            </Switch>
-                        </div>
+                        <PfSwitch v-model="diskVDevPoolData.forceReplace"
+                            :id="getIdKey('force-add-vdev')"
+                            label="Forcefully Replace Disk" />
                     </div>
                     <div class="button-group-row mt-2">
                         <button v-if="!adding" id="replace-disk-btn"
-                            class="btn btn-primary object-right justify-end mr-4 h-fit w-full"
+                            class="pf-v5-c-button pf-m-primary"
                             @click="replaceDiskBtn">Replace Disk</button>
                         <button disabled v-if="adding" id="finish" type="button"
-                            class="btn btn-primary object-right justify-end">
-                            <svg aria-hidden="true" role="status"
-                                class="inline w-4 h-4 mr-3 text-gray-200 animate-spin text-default"
-                                viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path
-                                    d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-                                    fill="currentColor" />
-                                <path
-                                    d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-                                    fill="text-success" />
-                            </svg>
+                            class="pf-v5-c-button pf-m-primary pf-m-in-progress">
                             Replacing...
                         </button>
                     </div>
                 </div>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 </template>
 <script setup lang="ts">
 import { ref, inject, Ref, computed, onMounted } from 'vue';
-import { Switch } from '@headlessui/vue';
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
+import PfSwitch from '../pf/PfSwitch.vue';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
 import { convertSizeToBytes, getDiskIDName, truncateName } from '../../composables/helpers';
 import { replaceDisk } from '../../composables/disks';

--- a/zfs/src/components/pf/PfSwitch.vue
+++ b/zfs/src/components/pf/PfSwitch.vue
@@ -1,12 +1,14 @@
 <template>
-  <label class="pf-v5-c-switch" :for="switchId">
+  <label class="pf-v5-c-switch" :class="{ 'pf-m-disabled': disabled }" :for="switchId">
     <input
       :id="switchId"
       class="pf-v5-c-switch__input"
       type="checkbox"
       role="switch"
       :aria-checked="modelValue"
+      :aria-disabled="disabled"
       :checked="modelValue"
+      :disabled="disabled"
       @change="onToggle"
     />
     <span class="pf-v5-c-switch__toggle">
@@ -33,11 +35,13 @@ interface PfSwitchProps {
   modelValue: boolean;
   label?: string;
   id?: string;
+  disabled?: boolean;
 }
 
 const props = withDefaults(defineProps<PfSwitchProps>(), {
   label: '',
   id: '',
+  disabled: false,
 });
 
 const emit = defineEmits<{
@@ -47,6 +51,8 @@ const emit = defineEmits<{
 const switchId = props.id || `pf-switch-${++_switchUid}`;
 
 function onToggle() {
-  emit('update:modelValue', !props.modelValue);
+  if (!props.disabled) {
+    emit('update:modelValue', !props.modelValue);
+  }
 }
 </script>

--- a/zfs/src/components/pools/AddVDevModal.vue
+++ b/zfs/src/components/pools/AddVDevModal.vue
@@ -43,29 +43,8 @@
                         class="mt-1 block text-sm font-medium leading-6 text-default">{{
                         upperCaseWord(newVDev.type) }}
                         (Mirror)</label>
-                    <Switch v-model="newVDev.isMirror"
-                        :class="[newVDev.isMirror ? 'bg-primary' : 'bg-accent', 'mt-1  relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                        <span class="sr-only">Use setting</span>
-                        <span
-                            :class="[newVDev.isMirror ? 'translate-x-5' : 'translate-x-0', ' relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                            <span
-                                :class="[newVDev.isMirror ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                aria-hidden="true">
-                                <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                    <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2"
-                                        stroke-linecap="round" stroke-linejoin="round" />
-                                </svg>
-                            </span>
-                            <span
-                                :class="[newVDev.isMirror ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                aria-hidden="true">
-                                <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                    <path
-                                        d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                </svg>
-                            </span>
-                        </span>
-                    </Switch>
+                    <PfSwitch v-model="newVDev.isMirror"
+                        :id="getIdKey('mirror-enabled')" />
                 </div>
 
                 <!-- Disk ID (Select) -->
@@ -201,33 +180,10 @@
                         </div>
                         <!-- Middle Expandable Section -->
                         <div class="flex flex-row items-center justify-center flex-grow text-center">
-                            <label :for="getIdKey('force-add-vdev')"
-                                class="mr-2 block text-sm font-medium leading-6 text-default">
-                                Forcefully Add
-                            </label>
-                            <Switch @click="toggleForceAdd" :id="getIdKey('force-add-vdev')"
-                                :class="[newVDev.forceAdd!.force ? 'bg-primary' : 'bg-accent', 'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                                <span class="sr-only">Use setting</span>
-                                <span
-                                    :class="[newVDev.forceAdd!.force ? 'translate-x-5' : 'translate-x-0', ' relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                    <span
-                                        :class="[newVDev.forceAdd!.force ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                        aria-hidden="true">
-                                        <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                            <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-                                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                        </svg>
-                                    </span>
-                                    <span
-                                        :class="[newVDev.forceAdd!.force ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                        aria-hidden="true">
-                                        <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                            <path
-                                                d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                        </svg>
-                                    </span>
-                                </span>
-                            </Switch>
+                            <PfSwitch :modelValue="newVDev.forceAdd!.force"
+                                @update:modelValue="toggleForceAdd"
+                                :id="getIdKey('force-add-vdev')"
+                                label="Forcefully Add" />
                         </div>
 
                         <!-- Right Button -->
@@ -269,7 +225,7 @@ input[type="checkbox"] {
 
 <script setup lang="ts">
 import { ref, inject, Ref, computed, onMounted } from 'vue';
-import { Switch } from '@headlessui/vue';
+import PfSwitch from '../pf/PfSwitch.vue';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
 import { upperCaseWord, convertSizeToBytes } from '../../composables/helpers';
 import { setRefreservation } from '../../composables/pools';

--- a/zfs/src/components/pools/DiskElement.vue
+++ b/zfs/src/components/pools/DiskElement.vue
@@ -23,12 +23,14 @@
 		</td>
 	</tr>
 	<!-- Child disks for REPLACING/MISSING state -->
-	<tr v-if="diskState == 'REPLACING' || diskState == 'MISSING'" v-for="disk in props.disk.children!"
-		:key="disk.name" class="pf-v5-c-table__tr border border-collapse border-default bg-accent text-default text-center">
-		<td class="pf-v5-c-table__td py-1" :class="truncateText" :title="disk.name" colspan="3">{{ props.disk.name }}</td>
-		<td class="pf-v5-c-table__td py-1" colspan="2"></td>
-		<td class="pf-v5-c-table__td py-1" colspan="2"></td>
-	</tr>
+	<template v-if="diskState == 'REPLACING' || diskState == 'MISSING'">
+		<tr v-for="disk in props.disk.children!" :key="disk.name"
+			class="pf-v5-c-table__tr border border-collapse border-default bg-accent text-default text-center">
+			<td class="pf-v5-c-table__td py-1" :class="truncateText" :title="disk.name" colspan="3">{{ props.disk.name }}</td>
+			<td class="pf-v5-c-table__td py-1" colspan="2"></td>
+			<td class="pf-v5-c-table__td py-1" colspan="2"></td>
+		</tr>
+	</template>
 
 	<div v-if="showDetachDiskModal">
 		<component :is="detachDiskComponent" :showFlag="showDetachDiskModal" @close="updateShowDetachDisk"

--- a/zfs/src/components/pools/DiskElement.vue
+++ b/zfs/src/components/pools/DiskElement.vue
@@ -1,118 +1,34 @@
 <template>
-	<div class="border-b border-t border-collapse border-default ">
-		<div class="grid grid-cols-9 grid-flow-cols w-full text-center bg-accent text-default ">
-			<!-- <div class="relative py-1 pl-3 pr-4 text-right font-medium sm:pr-6 lg:pr-8">
-				<span class="sr-only"></span>
-			</div> -->
-			<!-- <div name="disk-name" class="py-1 mt-1 col-span-2" :class="truncateText" :title="props.disk.name">{{ props.disk.name }} {{ diskSdName }}</div> -->
-			<div name="disk-name" class="py-1 mt-1 col-span-2" :class="truncateText" :title="props.disk.name">
-				{{ props.disk.name }} {{ diskSdName }} <span v-if="props.disk.replacingTarget">
-					<span class="text-orange-600">replacing</span> {{ props.disk.replacingTargetLabel }}</span>
-			</div>
-			<div name="disk-state" class="py-1 mt-1 col-span-1 font-semibold"
-				:class="[formatStatus(diskState), truncateText]" :title="diskState">{{ diskState }}</div>
-			<div name="disk-type" class="py-1 mt-1 col-span-1" :class="truncateText" :title="props.disk.type">{{
-				props.disk.type }}</div>
-			<div name="disk-temp" class="py-1 mt-1 col-span-1" :class="truncateText" :title="props.disk.temp">{{
-				props.disk.temp }}</div>
-			<div name="disk-capacity" class="py-1 mt-1 col-span-1" :class="truncateText" :title="props.disk.capacity">{{
-				props.disk.capacity }}</div>
-			<div name="disk-message" class="py-1 -mt-1 col-span-2">
-				<Status :isTrim="false" :disk="props.disk" :pool="props.pool" :isDisk="true" :isPoolList="true"
-					:isPoolDetail="false" :idKey="'trim-status-box'" ref="trimStatusBox"
-					:isTrimmable="getIsTrimmable()" />
-			</div>
-			<div name="disk-" class="col-span-1">
-				<div class="relative py-1 pl-3 pr-4 text-right font-medium sm:pr-6 lg:pr-8">
-					<Menu as="div" class="relative inline-block text-right">
-						<div>
-							<MenuButton @click.stop :disabled="!canDestructive" :aria-disabled="!canDestructive"
-								:title="!canDestructive ? 'Requires administrative privileges' : ''" :class="[
-									'flex items-center rounded-full p-2 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 focus:ring-offset-gray-100',
-									canDestructive ? 'bg-accent hover:text-white cursor-pointer'
-										: 'bg-accent/60 text-muted cursor-not-allowed'
-								]">
-								<span class="sr-only">Open options</span>
-								<EllipsisVerticalIcon class="w-5" aria-hidden="true" />
-							</MenuButton>
-						</div>
-
-						<transition enter-active-class="transition ease-out duration-100"
-							enter-from-class="transform opacity-0 scale-95"
-							enter-to-class="transform opacity-100 scale-100"
-							leave-active-class="transition ease-in duration-75"
-							leave-from-class="transform opacity-100 scale-100"
-							leave-to-class="transform opacity-0 scale-95">
-							<MenuItems
-								class="absolute right-0 z-10 w-max origin-top-right rounded-md bg-accent shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-								<div class="py-1">
-									<!-- <MenuItem as="div" v-slot="{ active }">
-                                        <a href="#" @click="clearDiskErrors(props.pool.name, props.disk.name)" :class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Clear Disk Errors</a>
-                                    </MenuItem> -->
-									<MenuItem as="div" v-slot="{ active }" >
-									<a v-if="props.vDev.disks.length > 1 && diskState !== 'REMOVED'" href="#"
-										@click="detachThisDisk(props.pool, props.disk)"
-										:class="[active ? 'bg-danger text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Detach
-										Disk</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" >
-									<a v-if="diskState == 'ONLINE'" href="#"
-										@click="offlineThisDisk(props.pool, props.disk)"
-										:class="[active ? 'bg-danger text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Offline
-										Disk</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" >
-									<a v-if="diskState == 'OFFLINE'" href="#"
-										@click="onlineThisDisk(props.pool, props.disk)"
-										:class="[active ? 'bg-green-600 text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Online
-										Disk</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" >
-									<a v-if="diskState !== 'REMOVED'" href="#"
-										@click="replaceThisDisk(props.pool, props.vDev, props.disk)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Replace
-										Disk</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" >
-									<a v-if="!trimActivity!.isActive && !trimActivity!.isPaused && props.pool.diskType != 'HDD' && getIsTrimmable() && diskState !== 'REMOVED'"
-										href="#" @click="trimThisDisk(props.pool, props.disk)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">TRIM
-										Disk</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" >
-									<a v-if="trimActivity!.isPaused && props.pool.diskType != 'HDD' && getIsTrimmable() && diskState !== 'REMOVED'"
-										href="#" @click="resumeTrim(props.pool, props.disk)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">TRIM
-										Disk</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" >
-									<a v-if="trimActivity!.isActive && props.pool.diskType != 'HDD' && getIsTrimmable() && diskState !== 'REMOVED'"
-										href="#" @click="pauseTrim(props.pool, props.disk)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Pause
-										TRIM (Disk)</a>
-									</MenuItem>
-									<MenuItem as="div" v-slot="{ active }" >
-									<a v-if="trimActivity!.isActive || trimActivity!.isPaused && props.pool.diskType != 'HDD' && getIsTrimmable() && diskState !== 'REMOVED'"
-										href="#" @click="stopTrim(props.pool, props.disk)"
-										:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Cancel
-										TRIM (Disk)</a>
-									</MenuItem>
-								</div>
-							</MenuItems>
-						</transition>
-					</Menu>
-				</div>
-			</div>
-		</div>
-		<div v-if="diskState == 'REPLACING' || diskState == 'MISSING'" class="border border-collapse border-default ">
-			<div v-for="disk in props.disk.children!"
-				class="grid grid-cols-9 grid-flow-cols w-full text-center bg-accent text-default">
-				<div class="py-1 mt-1 col-span-3" :class="truncateText" :title="disk.name">{{ props.disk.name }}</div>
-				<div class="py-1 mt-1 col-span-3"></div>
-				<div class="py-1 mt-1 col-span-3"></div>
-			</div>
-		</div>
-	</div>
+	<!-- Semantic table row for disk -->
+	<tr class="pf-v5-c-table__tr border-b border-t border-collapse border-default bg-accent text-default text-center">
+		<td class="pf-v5-c-table__td py-1" :class="truncateText" :title="props.disk.name">
+			{{ props.disk.name }} {{ diskSdName }} <span v-if="props.disk.replacingTarget">
+				<span class="text-orange-600">replacing</span> {{ props.disk.replacingTargetLabel }}</span>
+		</td>
+		<td class="pf-v5-c-table__td py-1 font-semibold"
+			:class="[formatStatus(diskState), truncateText]" :title="diskState">{{ diskState }}</td>
+		<td class="pf-v5-c-table__td py-1" :class="truncateText" :title="props.disk.type">{{
+			props.disk.type }}</td>
+		<td class="pf-v5-c-table__td py-1" :class="truncateText" :title="props.disk.temp">{{
+			props.disk.temp }}</td>
+		<td class="pf-v5-c-table__td py-1" :class="truncateText" :title="props.disk.capacity">{{
+			props.disk.capacity }}</td>
+		<td class="pf-v5-c-table__td py-1">
+			<Status :isTrim="false" :disk="props.disk" :pool="props.pool" :isDisk="true" :isPoolList="true"
+				:isPoolDetail="false" :idKey="'trim-status-box'" ref="trimStatusBox"
+				:isTrimmable="getIsTrimmable()" />
+		</td>
+		<td class="pf-v5-c-table__td py-1 text-right">
+			<PfDropdownMenu :items="diskMenuItems" :kebab="true" />
+		</td>
+	</tr>
+	<!-- Child disks for REPLACING/MISSING state -->
+	<tr v-if="diskState == 'REPLACING' || diskState == 'MISSING'" v-for="disk in props.disk.children!"
+		:key="disk.name" class="pf-v5-c-table__tr border border-collapse border-default bg-accent text-default text-center">
+		<td class="pf-v5-c-table__td py-1" :class="truncateText" :title="disk.name" colspan="3">{{ props.disk.name }}</td>
+		<td class="pf-v5-c-table__td py-1" colspan="2"></td>
+		<td class="pf-v5-c-table__td py-1" colspan="2"></td>
+	</tr>
 
 	<div v-if="showDetachDiskModal">
 		<component :is="detachDiskComponent" :showFlag="showDetachDiskModal" @close="updateShowDetachDisk"
@@ -162,12 +78,12 @@
 </template>
 <script setup lang="ts">
 import { ref, inject, Ref, watch, computed, provide, onMounted } from "vue";
-import { EllipsisVerticalIcon } from '@heroicons/vue/24/outline';
-import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue';
 import { scrubPool, clearErrors } from "../../composables/pools";
 import { labelClear, detachDisk, offlineDisk, onlineDisk, trimDisk } from "../../composables/disks";
 import { formatStatus } from '../../composables/helpers'
 import Status from "../common/Status.vue";
+import PfDropdownMenu from "../pf/PfDropdownMenu.vue";
+import type { DropdownMenuItem } from "../pf/PfDropdownMenu.vue";
 import { ZPool, VDev, VDevDisk, ZFSFileSystemInfo } from "@45drives/houston-common-lib";
 import { pushNotification, Notification } from '@45drives/houston-common-ui';
 import { PoolScanObjectGroup, PoolDiskStats, Activity, ConfirmationCallback } from "../../types";
@@ -193,6 +109,42 @@ const operationRunning = ref(false);
 const firstOptionToggle = ref(false);
 const secondOptionToggle = ref(false);
 const truncateText = inject<Ref<string>>('style-truncate-text')!;
+
+// Computed menu items for PfDropdownMenu (replaces HeadlessUI Menu)
+const diskMenuItems = computed<DropdownMenuItem[]>(() => {
+	const items: DropdownMenuItem[] = [];
+
+	if (!canDestructive.value) return items;
+
+	if (props.vDev.disks.length > 1 && diskState.value !== 'REMOVED') {
+		items.push({ label: 'Detach Disk', action: () => detachThisDisk(props.pool, props.disk) });
+	}
+	if (diskState.value == 'ONLINE') {
+		items.push({ label: 'Offline Disk', action: () => offlineThisDisk(props.pool, props.disk) });
+	}
+	if (diskState.value == 'OFFLINE') {
+		items.push({ label: 'Online Disk', action: () => onlineThisDisk(props.pool, props.disk) });
+	}
+	if (diskState.value !== 'REMOVED') {
+		items.push({ label: 'Replace Disk', action: () => replaceThisDisk(props.pool, props.vDev, props.disk) });
+	}
+
+	// TRIM actions
+	if (!trimActivity.value?.isActive && !trimActivity.value?.isPaused && props.pool.diskType != 'HDD' && getIsTrimmable() && diskState.value !== 'REMOVED') {
+		items.push({ label: 'TRIM Disk', action: () => trimThisDisk(props.pool, props.disk) });
+	}
+	if (trimActivity.value?.isPaused && props.pool.diskType != 'HDD' && getIsTrimmable() && diskState.value !== 'REMOVED') {
+		items.push({ label: 'Resume TRIM (Disk)', action: () => resumeTrim(props.pool, props.disk) });
+	}
+	if (trimActivity.value?.isActive && props.pool.diskType != 'HDD' && getIsTrimmable() && diskState.value !== 'REMOVED') {
+		items.push({ label: 'Pause TRIM (Disk)', action: () => pauseTrim(props.pool, props.disk) });
+	}
+	if ((trimActivity.value?.isActive || trimActivity.value?.isPaused) && props.pool.diskType != 'HDD' && getIsTrimmable() && diskState.value !== 'REMOVED') {
+		items.push({ label: 'Cancel TRIM (Disk)', action: () => stopTrim(props.pool, props.disk) });
+	}
+
+	return items;
+});
 
 function getIsTrimmable() {
 	selectedPool.value = props.pool;

--- a/zfs/src/components/pools/ImportPool.vue
+++ b/zfs/src/components/pools/ImportPool.vue
@@ -1,10 +1,5 @@
 <template>
-    <OldModal :isOpen="showImportModal" @close="showImportModal = false" :marginTop="'mt-28'" :width="'w-3/5'"
-        :minWidth="'min-w-3/5'" :closeOnBackgroundClick="false">
-        <template v-slot:title>
-            <legend class="flex justify-center">Import Pool</legend>
-        </template>
-        <template v-slot:content>
+    <PfModal :isOpen="showImportModal" title="Import Pool" variant="large" @close="showImportModal = false">
             <div>
                 <div class="grid grid-cols-3">
 
@@ -94,31 +89,8 @@
 
                     <!-- Switch for showing exported pools or showing deleted pools -->
                     <div class="mt-2 col-span-1">
-                        <label :for="getIdKey('show-destroyed-pools-switch')"
-                            class="mt-1 bg-default block text-sm leading-6 text-default">Show Destroyed Pools</label>
-                        <Switch v-model="showDeletedPools" :id="getIdKey('show-destroyed-pools-switch')"
-                            :class="[showDeletedPools! ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span
-                                :class="[showDeletedPools! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span
-                                    :class="[showDeletedPools! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span
-                                    :class="[showDeletedPools! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path
-                                            d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
+                        <PfSwitch v-model="showDeletedPools" :id="getIdKey('show-destroyed-pools-switch')"
+                            label="Show Destroyed Pools" />
                     </div>
 
                     <!-- Disk Identifier -->
@@ -135,9 +107,7 @@
 
                     <!-- Switch for renaming imported pool -->
                     <div class="mt-2 col-span-1">
-                        <label :for="getIdKey('rename-pool-switch')"
-                            class="mt-1 bg-default block text-sm leading-6 text-default">Rename Pool</label>
-                        <Switch v-model="importedPool.renamePool" :id="getIdKey('rename-pool-switch')"
+                        <PfSwitch v-model="importedPool.renamePool" :id="getIdKey('rename-pool-switch')"
                             :class="[importedPool.renamePool! ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
                             <span class="sr-only">Use setting</span>
                             <span
@@ -182,58 +152,14 @@
                     <div class="mt-2 col-span-1">
                         <label :for="getIdKey('read-only')"
                             class="mt-1 bg-default block text-sm leading-6 text-default">Read Only</label>
-                        <Switch v-model="importedPool.readOnly" :id="getIdKey('read-only')"
-                            :class="[importedPool.readOnly! ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span
-                                :class="[importedPool.readOnly! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span
-                                    :class="[importedPool.readOnly! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span
-                                    :class="[importedPool.readOnly! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path
-                                            d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
+                        <PfSwitch v-model="importedPool.readOnly" :id="getIdKey('read-only')" label="Read Only" />
                     </div>
 
                     <!-- Switch for Recovery Mode -->
                     <div class="mt-2 col-span-1">
                         <label :for="getIdKey('recovery-mode')"
                             class="mt-1 bg-default block text-sm leading-6 text-default">Recovery Mode</label>
-                        <Switch v-model="importedPool.recoveryMode" :id="getIdKey('recovery-mode')"
-                            :class="[importedPool.recoveryMode! ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span
-                                :class="[importedPool.recoveryMode! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span
-                                    :class="[importedPool.recoveryMode! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span
-                                    :class="[importedPool.recoveryMode! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path
-                                            d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
+                        <PfSwitch v-model="importedPool.recoveryMode" :id="getIdKey('recovery-mode')" label="Recovery Mode" />
                     </div>
 
                     <!-- Switch for Ignore Missing Log Devices -->
@@ -241,93 +167,27 @@
                         <label :for="getIdKey('ignore-missing-logs')"
                             class="mt-1 bg-default block text-sm leading-6 text-default">Ignore Missing Log
                             Devices</label>
-                        <Switch v-model="importedPool.ignoreMissingLog" :id="getIdKey('ignore-missing-logs')"
-                            :class="[importedPool.ignoreMissingLog! ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span
-                                :class="[importedPool.ignoreMissingLog! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span
-                                    :class="[importedPool.ignoreMissingLog! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span
-                                    :class="[importedPool.ignoreMissingLog! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path
-                                            d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
+                        <PfSwitch v-model="importedPool.ignoreMissingLog" :id="getIdKey('ignore-missing-logs')" label="Ignore Missing Log Devices" />
                     </div>
 
                     <!-- Switch for Mount Filesystems (ON by default, if OFF then execute command) -->
                     <div class="mt-2 col-span-1">
                         <label :for="getIdKey('mount-filesystems')"
                             class="mt-1 bg-default block text-sm leading-6 text-default">Mount File Systems</label>
-                        <Switch v-model="importedPool.mountFileSystems" :id="getIdKey('mount-filesystems')"
-                            :class="[importedPool.mountFileSystems! ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span
-                                :class="[importedPool.mountFileSystems! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span
-                                    :class="[importedPool.mountFileSystems! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span
-                                    :class="[importedPool.mountFileSystems! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path
-                                            d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
+                        <PfSwitch v-model="importedPool.mountFileSystems" :id="getIdKey('mount-filesystems')" label="Mount File Systems" />
                     </div>
 
                     <!-- Switch for Force Import -->
                     <div class="mt-2 col-span-1">
                         <label :for="getIdKey('force-import')"
                             class="mt-1 bg-default block text-sm leading-6 text-default">Forcefully Import</label>
-                        <Switch v-model="importedPool.forceImport" :id="getIdKey('force-import')"
-                            :class="[importedPool.forceImport! ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span
-                                :class="[importedPool.forceImport! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span
-                                    :class="[importedPool.forceImport! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span
-                                    :class="[importedPool.forceImport! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path
-                                            d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
+                        <PfSwitch v-model="importedPool.forceImport" :id="getIdKey('force-import')" label="Forcefully Import" />
                     </div>
 
                 </div>
             </div>
         </template>
-        <template v-slot:footer>
+        <template #footer>
             <div class="w-full grid grid-rows-2">
                 <div class="w-full row-start-1">
                     <div class="mt-2">
@@ -336,12 +196,12 @@
                 </div>
                 <div class="button-group-row w-full row-start-2 justify-between mt-2">
                     <button @click="showImportModal = false" :id="getIdKey('cancel-import')" name="cancel-import"
-                        class="mt-1 btn btn-danger object-left justify-start h-fit">Cancel</button>
+                        class="pf-v5-c-button pf-m-danger mt-1">Cancel</button>
                     <button v-if="!importing" @click="importPoolBtn()" :id="getIdKey('import-pool-btn')"
                         name="import-pool-btn"
-                        class="mt-1 btn btn-primary object-right justify-end h-fit">Import</button>
+                        class="pf-v5-c-button pf-m-primary mt-1">Import</button>
                     <button v-if="importing" disabled :id="getIdKey('import-pool-spinner')" type="button"
-                        class="btn btn-danger object-right justify-end">
+                        class="pf-v5-c-button pf-m-primary pf-m-in-progress">
                         <svg aria-hidden="true" role="status"
                             class="inline w-4 h-4 mr-3 text-gray-200 animate-spin text-default" viewBox="0 0 100 101"
                             fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -357,12 +217,12 @@
                 </div>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 </template>
 <script setup lang="ts">
 import { inject, ref, Ref, computed, watch } from 'vue';
-import { Switch } from '@headlessui/vue';
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
+import PfSwitch from '../pf/PfSwitch.vue';
 import LoadingSpinner from '../common/LoadingSpinner.vue';
 import { ExclamationCircleIcon } from '@heroicons/vue/24/outline';
 import { loadImportablePools, loadImportableDestroyedPools } from '../../composables/loadImportables';

--- a/zfs/src/components/pools/ImportPool.vue
+++ b/zfs/src/components/pools/ImportPool.vue
@@ -108,28 +108,7 @@
                     <!-- Switch for renaming imported pool -->
                     <div class="mt-2 col-span-1">
                         <PfSwitch v-model="importedPool.renamePool" :id="getIdKey('rename-pool-switch')"
-                            :class="[importedPool.renamePool! ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span
-                                :class="[importedPool.renamePool! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span
-                                    :class="[importedPool.renamePool! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span
-                                    :class="[importedPool.renamePool! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                    aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path
-                                            d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
+                            label="Rename Pool" />
                     </div>
                     <!-- If Switch is ON, show text input for new pool name -->
                     <div v-if="importedPool.renamePool" class="mt-2 col-span-2">
@@ -150,43 +129,31 @@
 
                     <!-- Switch for Read Only -->
                     <div class="mt-2 col-span-1">
-                        <label :for="getIdKey('read-only')"
-                            class="mt-1 bg-default block text-sm leading-6 text-default">Read Only</label>
                         <PfSwitch v-model="importedPool.readOnly" :id="getIdKey('read-only')" label="Read Only" />
                     </div>
 
                     <!-- Switch for Recovery Mode -->
                     <div class="mt-2 col-span-1">
-                        <label :for="getIdKey('recovery-mode')"
-                            class="mt-1 bg-default block text-sm leading-6 text-default">Recovery Mode</label>
                         <PfSwitch v-model="importedPool.recoveryMode" :id="getIdKey('recovery-mode')" label="Recovery Mode" />
                     </div>
 
                     <!-- Switch for Ignore Missing Log Devices -->
                     <div class="mt-2 col-span-1">
-                        <label :for="getIdKey('ignore-missing-logs')"
-                            class="mt-1 bg-default block text-sm leading-6 text-default">Ignore Missing Log
-                            Devices</label>
                         <PfSwitch v-model="importedPool.ignoreMissingLog" :id="getIdKey('ignore-missing-logs')" label="Ignore Missing Log Devices" />
                     </div>
 
                     <!-- Switch for Mount Filesystems (ON by default, if OFF then execute command) -->
                     <div class="mt-2 col-span-1">
-                        <label :for="getIdKey('mount-filesystems')"
-                            class="mt-1 bg-default block text-sm leading-6 text-default">Mount File Systems</label>
                         <PfSwitch v-model="importedPool.mountFileSystems" :id="getIdKey('mount-filesystems')" label="Mount File Systems" />
                     </div>
 
                     <!-- Switch for Force Import -->
                     <div class="mt-2 col-span-1">
-                        <label :for="getIdKey('force-import')"
-                            class="mt-1 bg-default block text-sm leading-6 text-default">Forcefully Import</label>
                         <PfSwitch v-model="importedPool.forceImport" :id="getIdKey('force-import')" label="Forcefully Import" />
                     </div>
 
                 </div>
             </div>
-        </template>
         <template #footer>
             <div class="w-full grid grid-rows-2">
                 <div class="w-full row-start-1">

--- a/zfs/src/components/pools/PoolDetail.vue
+++ b/zfs/src/components/pools/PoolDetail.vue
@@ -1,11 +1,10 @@
 <template>
-	<OldModal @close="closeModal" :close-on-background-click="false" :isOpen="showPoolDetails" :marginTop="'mt-28'"
-		:width="'w-7/12'" :minWidth="'min-w-7/12'" :initialFocus="null">
-		<template v-slot:title>
+	<PfModal :isOpen="showPoolDetails" :title="'Pool Details - ' + props.pool.name" variant="large"
+		@close="closeModal">
+		<div>
 			<Navigation :navigationItems="navigation" :currentNavigationItem="currentNavigationItem"
 				:navigationCallback="navigationCallback" :show="show" />
-		</template>
-		<template v-slot:content>
+		</div>
 			<div v-if="navTag == 'stats'">
 				<div class="mt-6 grid grid-cols-3 grid-rows-2 text-default">
 					<PoolCapacity :id="getIdKey('pool-visual-capacity')" :fillColor="capacityColor"
@@ -118,227 +117,83 @@
 
 					<!-- auto-expand -->
 					<div class="col-span-1 col-start-1 row-start-3">
-						<label :for="getIdKey('settings-pool-auto-expand')"
-							class="mt-1 block text-sm leading-6 text-default">Auto-Expand Pool</label>
-						<Switch v-model="poolConfig.properties.autoExpand" :id="getIdKey('settings-pool-auto-expand')"
-							:disabled="settingsLocked" :aria-disabled="settingsLocked"
-							:title="settingsLocked ? 'Requires administrative privileges' : ''" :class="[
-								settingsLocked ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
-								poolConfig.properties.autoExpand ? 'bg-secondary' : 'bg-accent',
-								'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2'
-							]">
-							<span class="sr-only">Use setting</span>
-							<span
-								:class="[poolConfig.properties.autoExpand ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-								<span
-									:class="[poolConfig.properties.autoExpand ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-									aria-hidden="true">
-									<svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-										<path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-											stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-									</svg>
-								</span>
-								<span
-									:class="[poolConfig.properties.autoExpand ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-									aria-hidden="true">
-									<svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-										<path
-											d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-									</svg>
-								</span>
-							</span>
-						</Switch>
+						<PfSwitch v-model="poolConfig.properties.autoExpand"
+							:id="getIdKey('settings-pool-auto-expand')"
+							label="Auto-Expand Pool" />
 					</div>
 
 					<!-- auto-replace -->
 					<div class="col-span-1 col-start-2 row-start-3">
-						<label :for="getIdKey('settings-pool-auto-replace')"
-							class="mt-1 block text-sm leading-6 text-default">Auto-Replace Drives</label>
-						<Switch v-model="poolConfig.properties.autoReplace" :id="getIdKey('settings-pool-auto-replace')"
-							:disabled="settingsLocked" :aria-disabled="settingsLocked"
-							:title="settingsLocked ? 'Requires administrative privileges' : ''"
-							:class="[
-								settingsLocked ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer', poolConfig.properties.autoReplace ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-							<span class="sr-only">Use setting</span>
-							<span
-								:class="[poolConfig.properties.autoReplace ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-								<span
-									:class="[poolConfig.properties.autoReplace ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-									aria-hidden="true">
-									<svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-										<path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-											stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-									</svg>
-								</span>
-								<span
-									:class="[poolConfig.properties.autoReplace ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-									aria-hidden="true">
-									<svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-										<path
-											d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-									</svg>
-								</span>
-							</span>
-						</Switch>
+						<PfSwitch v-model="poolConfig.properties.autoReplace"
+							:id="getIdKey('settings-pool-auto-replace')"
+							label="Auto-Replace Drives" />
 					</div>
 
 					<!-- display snapshots in filesystem list -->
 					<div class="col-span-2 col-start-3 row-start-3">
-						<label :for="getIdKey('settings-pool-display-snapshots')"
-							class="mt-1 block text-sm leading-6 text-default">List Snapshots With File Systems</label>
-						<Switch v-model="poolConfig.properties.listSnapshots"
-							:id="getIdKey('settings-pool-display-snapshots')" :disabled="settingsLocked"
-							:aria-disabled="settingsLocked"
-							:title="settingsLocked ? 'Requires administrative privileges' : ''"
-							:class="[
-								settingsLocked ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer', poolConfig.properties.listSnapshots ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-							<span class="sr-only">Use setting</span>
-							<span
-								:class="[poolConfig.properties.listSnapshots ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-								<span
-									:class="[poolConfig.properties.listSnapshots ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-									aria-hidden="true">
-									<svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-										<path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-											stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-									</svg>
-								</span>
-								<span
-									:class="[poolConfig.properties.listSnapshots ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-									aria-hidden="true">
-									<svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-										<path
-											d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-									</svg>
-								</span>
-							</span>
-						</Switch>
+						<PfSwitch v-model="poolConfig.properties.listSnapshots"
+							:id="getIdKey('settings-pool-display-snapshots')"
+							label="List Snapshots With File Systems" />
 					</div>
 
 					<!-- delegation (Allow non-privileged user access based on the dataset permissions)-->
 					<div class="col-span-2 col-start-1 row-start-4">
-						<div class="col-span-1 flex flex-row gap-2 mt-1 text-center leading-6">
-							<label :for="getIdKey('settings-pool-delegation')"
-								class="block text-sm text-default">Delegation</label>
-							<p class="text-xs text-muted mt-0.5">(Access based on dataset permissions)</p>
-						</div>
-						<Switch :initialFocus="null" v-model="poolConfig.properties.delegation"
-							:id="getIdKey('settings-pool-delegation')" :disabled="settingsLocked"
-							:aria-disabled="settingsLocked"
-							:title="settingsLocked ? 'Requires administrative privileges' : ''"
-							:class="[
-								settingsLocked ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer', poolConfig.properties.delegation ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-							<span class="sr-only">Use setting</span>
-							<span
-								:class="[poolConfig.properties.delegation ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-								<span
-									:class="[poolConfig.properties.delegation ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-									aria-hidden="true">
-									<svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-										<path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-											stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-									</svg>
-								</span>
-								<span
-									:class="[poolConfig.properties.delegation ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-									aria-hidden="true">
-									<svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-										<path
-											d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-									</svg>
-								</span>
-							</span>
-						</Switch>
+						<PfSwitch v-model="poolConfig.properties.delegation"
+							:id="getIdKey('settings-pool-delegation')"
+							label="Delegation" />
+						<p class="text-xs text-muted mt-0.5">(Access based on dataset permissions)</p>
 					</div>
 
 					<!-- auto-trim -->
 					<div v-if="props.pool.diskType == 'SSD' || props.pool.diskType == 'Hybrid'"
 						class="col-span-1 col-start-3 row-start-4">
-						<label :for="getIdKey('settings-pool-auto-trim')"
-							class="mt-1 block text-sm leading-6 text-default">Auto-TRIM Pool</label>
-						<Switch v-model="poolConfig.properties.autoTrim" :id="getIdKey('settings-pool-auto-trim')"
-							:disabled="settingsLocked" :aria-disabled="settingsLocked"
-							:title="settingsLocked ? 'Requires administrative privileges' : ''"
-							:class="[
-								settingsLocked ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer', poolConfig.properties.autoTrim ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-							<span class="sr-only">Use setting</span>
-							<span
-								:class="[poolConfig.properties.autoTrim ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-								<span
-									:class="[poolConfig.properties.autoTrim ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-									aria-hidden="true">
-									<svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-										<path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor"
-											stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-									</svg>
-								</span>
-								<span
-									:class="[poolConfig.properties.autoTrim ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-									aria-hidden="true">
-									<svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-										<path
-											d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-									</svg>
-								</span>
-							</span>
-						</Switch>
+						<PfSwitch v-model="poolConfig.properties.autoTrim"
+							:id="getIdKey('settings-pool-auto-trim')"
+							label="Auto-TRIM Pool" />
 					</div>
 
 				</div>
 			</div>
-		</template>
-		<template v-slot:footer>
+		<template #footer>
 			<div class="button-group-row w-full justify-between">
 				<div class="mt-2 justify-self-start">
 					<button @click="showPoolDetails = false" :id="getIdKey('close-details-btn')"
-						name="close-details-btn" class="mt-1 btn btn-danger">Close</button>
+						name="close-details-btn" class="pf-v5-c-button pf-m-danger mt-1">Close</button>
 				</div>
-				<div class="justofy-self-center">
+				<div class="justify-self-center">
 					<div class="button-group-row mt-2 justify-self-center">
 						<p class="text-danger" v-if="commentFeedback">{{ commentFeedback }}</p>
-
 					</div>
 				</div>
 				<div class="justify-self-end">
 					<div v-if="navTag == 'topology'">
 						<div class="mt-2">
 							<button v-if="canDestructive" @click="addVDevButton()" :id="getIdKey('add-vdev-btn')"
-								name="add-vdev-btn" class="mt-1 btn btn-primary">Add Virtual Device</button>
+								name="add-vdev-btn" class="pf-v5-c-button pf-m-primary mt-1">Add Virtual Device</button>
 						</div>
 					</div>
 					<div v-if="navTag == 'snapshots'">
 						<div class="mt-2">
 							<button v-if="canDestructive" @click="createSnapshotBtn()"
 								:id="getIdKey('create-snap-wizard-btn')" name="create-snap-wizard-btn"
-								class="mt-1 btn btn-primary">Create Snapshot</button>
+								class="pf-v5-c-button pf-m-primary mt-1">Create Snapshot</button>
 						</div>
 					</div>
 					<div v-if="navTag == 'settings'">
 						<div class="button-group-row mt-2">
 							<button v-if="!saving" @click="poolConfigureBtn(); props.confirmation;"
 								:id="getIdKey('settings-save-btn')" name="settings-save-btn"
-								class="mt-1 btn btn-primary">Save Changes</button>
+								class="pf-v5-c-button pf-m-primary mt-1">Save Changes</button>
 							<button disabled v-if="saving" id="finish" type="button"
-								class="btn btn-primary object-right justify-end">
-								<svg aria-hidden="true" role="status"
-									class="inline w-4 h-4 mr-3 text-gray-200 animate-spin text-default"
-									viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
-									<path
-										d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-										fill="currentColor" />
-									<path
-										d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-										fill="text-success" />
-								</svg>
+								class="pf-v5-c-button pf-m-primary pf-m-in-progress">
 								Saving...
 							</button>
 						</div>
-
 					</div>
 				</div>
 			</div>
 		</template>
-	</OldModal>
+	</PfModal>
 
 	<div v-if="showSnapshotModal">
 		<component :is="createSnapshotComponent" @close="updateShowNewSnapshot" :poolName="props.pool.name"
@@ -354,11 +209,11 @@
 
 <script setup lang="ts">
 import { reactive, ref, inject, Ref, computed, provide, watch } from 'vue';
-import { Switch } from '@headlessui/vue';
 import { configurePool } from '../../composables/pools';
 import { getTimestampString, upperCaseWord, isBoolOnOff, loadScanActivities, loadTrimActivities, formatStatus, getCapacityColor, convertBytesToSize } from '../../composables/helpers';
 import { loadDisksThenPools, loadScanObjectGroup, loadDiskStats } from '../../composables/loadData';
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
+import PfSwitch from '../pf/PfSwitch.vue';
 import PoolCapacity from '../common/PoolCapacity.vue';
 import Navigation from '../common/Navigation.vue';
 import PoolDetailDiskCard from '../disks/PoolDetailDiskCard.vue';

--- a/zfs/src/components/pools/PoolDetail.vue
+++ b/zfs/src/components/pools/PoolDetail.vue
@@ -5,155 +5,158 @@
 			<Navigation :navigationItems="navigation" :currentNavigationItem="currentNavigationItem"
 				:navigationCallback="navigationCallback" :show="show" />
 		</div>
-			<div v-if="navTag == 'stats'">
-				<div class="mt-6 grid grid-cols-3 grid-rows-2 text-default">
-					<PoolCapacity :id="getIdKey('pool-visual-capacity')" :fillColor="capacityColor"
-						:name="props.pool.name" :totalSize="props.pool.properties.size"
-						:percentage="props.pool.properties.capacity" :radius="50" :coordX="60" :coordY="60"
-						:strokeWidth="10" :percentFontSize="'text-2xl'" class="w-full col-span-3 grow" />
-					<div
-						class="mt-2 px-8 col-span-3 row-start-2 grid grid-cols-3 justify-items-center min-w-fit max-w-fit">
-						<div class="m-2 col-span-1">
-							<p :id="getIdKey('pool-health')" name="pool-health" class="text-lg">Health: <span
-									:class="formatStatus(props.pool.status)" class="">{{ props.pool.status }}</span></p>
-							<p :id="getIdKey('pool-errors')" name="pool-errors" class="text-sm">Errors: <span
-									:class="formatStatus(props.pool.status)" class="">{{ props.pool.errorCount }}</span>
-								<br />as of {{ getTimestampString() }}
-							</p>
-							<p :id="getIdKey('pool-refreservation')" name="pool-refreservation" class="text-sm">
-								Refreservation: {{
-								convertBytesToSize(props.pool.properties.refreservationRawSize!) }} ({{
-								convertBytesToSize(props.pool.properties.refreservationRawSize!) }} ({{
-								props.pool.properties.refreservationPercent }}%)</p>
-						</div>
-						<div class="m-2 col-span-1">
-							<p :id="getIdKey('pool-altroot')" name="pool-altroot" class="text-base"
-								:title="props.pool.properties.altroot == '' || props.pool.properties.altroot == '-' ? 'None' : props.pool.properties.altroot"
-								:class="truncateText">Alt Root: {{ props.pool.properties.altroot == '' ||
-								props.pool.properties.altroot == '-' ? 'None' : props.pool.properties.altroot }}</p>
-							<p :id="getIdKey('pool-devices')" name="pool-devices" class="text-base">Devices: {{
-								getNumDevices }}</p>
-							<p :id="getIdKey('pool-disks')" name="pool-disks" class="text-base">Disks: {{ getNumDisks }}
-							</p>
-						</div>
-						<div class="m-2 col-span-1">
-							<p :id="getIdKey('pool-allocated')" name="pool-allocated" class="text-base">Used: {{
-								props.pool.properties.allocated }}</p>
-							<p :id="getIdKey('pool-free')" name="pool-free" class="text-base">RAW Space Available: {{
-								props.pool.properties.free }}</p>
-							<p :id="getIdKey('pool-free')" name="pool-free" class="text-base">Actual Space Available: {{
-								props.pool.properties.available }}</p>
-							<p :id="getIdKey('pool-size')" name="pool-size" class="text-base">Total: {{
-								props.pool.properties.size }}</p>
-						</div>
+		<div v-if="navTag == 'stats'">
+			<div class="mt-6 grid grid-cols-3 grid-rows-2 text-default">
+				<PoolCapacity :id="getIdKey('pool-visual-capacity')" :fillColor="capacityColor"
+					:name="props.pool.name" :totalSize="props.pool.properties.size"
+					:percentage="props.pool.properties.capacity" :radius="50" :coordX="60" :coordY="60"
+					:strokeWidth="10" :percentFontSize="'text-2xl'" class="w-full col-span-3 grow" />
+				<div
+					class="mt-2 px-8 col-span-3 row-start-2 grid grid-cols-3 justify-items-center min-w-fit max-w-fit">
+					<div class="m-2 col-span-1">
+						<p :id="getIdKey('pool-health')" name="pool-health" class="text-lg">Health: <span
+								:class="formatStatus(props.pool.status)" class="">{{ props.pool.status }}</span></p>
+						<p :id="getIdKey('pool-errors')" name="pool-errors" class="text-sm">Errors: <span
+								:class="formatStatus(props.pool.status)" class="">{{ props.pool.errorCount }}</span>
+							<br />as of {{ getTimestampString() }}
+						</p>
+						<p :id="getIdKey('pool-refreservation')" name="pool-refreservation" class="text-sm">
+							Refreservation: {{
+							convertBytesToSize(props.pool.properties.refreservationRawSize!) }} ({{
+							convertBytesToSize(props.pool.properties.refreservationRawSize!) }} ({{
+							props.pool.properties.refreservationPercent }}%)</p>
+					</div>
+					<div class="m-2 col-span-1">
+						<p :id="getIdKey('pool-altroot')" name="pool-altroot" class="text-base"
+							:title="props.pool.properties.altroot == '' || props.pool.properties.altroot == '-' ? 'None' : props.pool.properties.altroot"
+							:class="truncateText">Alt Root: {{ props.pool.properties.altroot == '' ||
+							props.pool.properties.altroot == '-' ? 'None' : props.pool.properties.altroot }}</p>
+						<p :id="getIdKey('pool-devices')" name="pool-devices" class="text-base">Devices: {{
+							getNumDevices }}</p>
+						<p :id="getIdKey('pool-disks')" name="pool-disks" class="text-base">Disks: {{ getNumDisks }}
+						</p>
+					</div>
+					<div class="m-2 col-span-1">
+						<p :id="getIdKey('pool-allocated')" name="pool-allocated" class="text-base">Used: {{
+							props.pool.properties.allocated }}</p>
+						<p :id="getIdKey('pool-free')" name="pool-free" class="text-base">RAW Space Available: {{
+							props.pool.properties.free }}</p>
+						<p :id="getIdKey('pool-free')" name="pool-free" class="text-base">Actual Space Available: {{
+							props.pool.properties.available }}</p>
+						<p :id="getIdKey('pool-size')" name="pool-size" class="text-base">Total: {{
+							props.pool.properties.size }}</p>
 					</div>
 				</div>
 			</div>
+		</div>
 
-			<div v-if="navTag == 'topology'" class="mt-2 grid" :class="`grid-cols-${props.pool.vdevs.length}`">
-				<div v-for="vDev, vDevIdx in props.pool.vdevs" :key="vDevIdx"
-					class="p-2 m-2 rounded-md border border-default bg-accent">
-					<legend class="mb-1 text-base font-medium leading-6 text-default">{{ vDev.name }} ({{ vDev.type }})
-					</legend>
+		<div v-if="navTag == 'topology'" class="mt-2 grid" :class="`grid-cols-${props.pool.vdevs.length}`">
+			<div v-for="vDev, vDevIdx in props.pool.vdevs" :key="vDevIdx"
+				class="p-2 m-2 rounded-md border border-default bg-accent">
+				<legend class="mb-1 text-base font-medium leading-6 text-default">{{ vDev.name }} ({{ vDev.type }})
+				</legend>
 
-					<div class="grid" :class="vDev.disks.length < 2 ? 'grid-cols-1' : 'grid-cols-2'">
-						<div v-for="disk, diskIdx in vDev.disks" :key="diskIdx" class="m-1">
-							<PoolDetailDiskCard :disk="vDev.disks[diskIdx]" />
-						</div>
+				<div class="grid" :class="vDev.disks.length < 2 ? 'grid-cols-1' : 'grid-cols-2'">
+					<div v-for="disk, diskIdx in vDev.disks" :key="diskIdx" class="m-1">
+						<PoolDetailDiskCard :disk="vDev.disks[diskIdx]" />
 					</div>
 				</div>
 			</div>
+		</div>
 
+		<div v-if="navTag == 'snapshots'" class="w-full text-center min-w-fit">
+			<component :is="snapshotListComponent" :pool="props.pool" :item="'pool'" />
+		</div>
 
-			<div v-if="navTag == 'snapshots'" class="w-full text-center min-w-fit">
-				<component :is="snapshotListComponent" :pool="props.pool" :item="'pool'" />
-			</div>
-
-			<div v-if="navTag == 'settings'">
-				<div class="grid grid-cols-4 gap-2">
-					<div class="mt-2 col-span-1 col-start-1 row-start-1">
-						<p :id="getIdKey('settings-pool-name')" name="settings-pool-name"
-							class="text-base text-default">Pool</p>
-						<p class="mt-1 py-1.5" :class="truncateText" :title="poolConfig.name">{{ poolConfig.name }}</p>
-					</div>
-					<div class="mt-2 col-span-1 col-start-2 row-start-1">
-						<p :id="getIdKey('settings-pool-readonly')" name="settings-pool-readonly"
-							class="text-base text-default">Read Only</p>
-						<p class="mt-1 py-1.5">{{ upperCaseWord(isBoolOnOff(poolConfig.properties.readOnly)) }}</p>
-					</div>
-					<div class="mt-2 col-span-1 col-start-3 row-start-1">
-						<p :id="getIdKey('settings-pool-guid')" name="settings-pool-guid"
-							class="text-base text-default">GUID</p>
-						<p class="mt-1 py-1.5">{{ poolConfig.guid }}</p>
-					</div>
-
-					<div class="mt-2 col-span-1 col-start-4 row-start-1">
-						<label :for="getIdKey('settings-pool-sector-size')"
-							class="bg-default block text-base leading-6 text-default">Sector Size</label>
-						<p :id="getIdKey('settings-pool-sector-size')" name="settings-pool-sector-size"
-							class="mt-1 py-1.5">{{ calculateSectorSize(Number(poolConfig.properties.sector)) }}</p>
-					</div>
-
-					<div class="mt-2 col-span-1 col-start-1 row-start-2">
-						<label :for="getIdKey('settings-pool-fail-mode')"
-							class="bg-default block text-base leading-6 text-default">Fail Mode</label>
-						<select :id="getIdKey('settings-pool-fail-mode')" v-model="poolConfig.failMode"
-							:disabled="settingsLocked"
-							:title="settingsLocked ? 'Requires administrative privileges' : ''" name="pool-fail-mode"
-							class="mt-1 block w-full rounded-md border-0 py-1.5 text-default bg-default ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-slate-600 sm:text-sm sm:leading-6">
-							<option value="wait">Wait</option>
-							<option value="continue">Continue</option>
-							<option value="panic">Panic</option>
-						</select>
-					</div>
-
-
-					<div class="mt-2 col-span-3 col-start-2 row-start-2">
-						<p :for="getIdKey('settings-pool-comment')" class="text-base text-default">Comment</p>
-						<input :id="getIdKey('settings-pool-comment')" v-model="poolConfig.comment"
-							name="setting-pool-comment" placeholder="Enter a comment here" type="text"
-							class="input-textlike mt-1 block w-full rounded-md border-0 py-1.5 px-1.5 text-default shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-muted focus:ring-2 focus:ring-inset focus:ring-slate-300 sm:text-sm sm:leading-6" />
-					</div>
-
-					<!-- auto-expand -->
-					<div class="col-span-1 col-start-1 row-start-3">
-						<PfSwitch v-model="poolConfig.properties.autoExpand"
-							:id="getIdKey('settings-pool-auto-expand')"
-							label="Auto-Expand Pool" />
-					</div>
-
-					<!-- auto-replace -->
-					<div class="col-span-1 col-start-2 row-start-3">
-						<PfSwitch v-model="poolConfig.properties.autoReplace"
-							:id="getIdKey('settings-pool-auto-replace')"
-							label="Auto-Replace Drives" />
-					</div>
-
-					<!-- display snapshots in filesystem list -->
-					<div class="col-span-2 col-start-3 row-start-3">
-						<PfSwitch v-model="poolConfig.properties.listSnapshots"
-							:id="getIdKey('settings-pool-display-snapshots')"
-							label="List Snapshots With File Systems" />
-					</div>
-
-					<!-- delegation (Allow non-privileged user access based on the dataset permissions)-->
-					<div class="col-span-2 col-start-1 row-start-4">
-						<PfSwitch v-model="poolConfig.properties.delegation"
-							:id="getIdKey('settings-pool-delegation')"
-							label="Delegation" />
-						<p class="text-xs text-muted mt-0.5">(Access based on dataset permissions)</p>
-					</div>
-
-					<!-- auto-trim -->
-					<div v-if="props.pool.diskType == 'SSD' || props.pool.diskType == 'Hybrid'"
-						class="col-span-1 col-start-3 row-start-4">
-						<PfSwitch v-model="poolConfig.properties.autoTrim"
-							:id="getIdKey('settings-pool-auto-trim')"
-							label="Auto-TRIM Pool" />
-					</div>
-
+		<div v-if="navTag == 'settings'">
+			<div class="grid grid-cols-4 gap-2">
+				<div class="mt-2 col-span-1 col-start-1 row-start-1">
+					<p :id="getIdKey('settings-pool-name')" name="settings-pool-name"
+						class="text-base text-default">Pool</p>
+					<p class="mt-1 py-1.5" :class="truncateText" :title="poolConfig.name">{{ poolConfig.name }}</p>
 				</div>
+				<div class="mt-2 col-span-1 col-start-2 row-start-1">
+					<p :id="getIdKey('settings-pool-readonly')" name="settings-pool-readonly"
+						class="text-base text-default">Read Only</p>
+					<p class="mt-1 py-1.5">{{ upperCaseWord(isBoolOnOff(poolConfig.properties.readOnly)) }}</p>
+				</div>
+				<div class="mt-2 col-span-1 col-start-3 row-start-1">
+					<p :id="getIdKey('settings-pool-guid')" name="settings-pool-guid"
+						class="text-base text-default">GUID</p>
+					<p class="mt-1 py-1.5">{{ poolConfig.guid }}</p>
+				</div>
+
+				<div class="mt-2 col-span-1 col-start-4 row-start-1">
+					<label :for="getIdKey('settings-pool-sector-size')"
+						class="bg-default block text-base leading-6 text-default">Sector Size</label>
+					<p :id="getIdKey('settings-pool-sector-size')" name="settings-pool-sector-size"
+						class="mt-1 py-1.5">{{ calculateSectorSize(Number(poolConfig.properties.sector)) }}</p>
+				</div>
+
+				<div class="mt-2 col-span-1 col-start-1 row-start-2">
+					<label :for="getIdKey('settings-pool-fail-mode')"
+						class="bg-default block text-base leading-6 text-default">Fail Mode</label>
+					<select :id="getIdKey('settings-pool-fail-mode')" v-model="poolConfig.failMode"
+						:disabled="settingsLocked"
+						:title="settingsLocked ? 'Requires administrative privileges' : ''" name="pool-fail-mode"
+						class="mt-1 block w-full rounded-md border-0 py-1.5 text-default bg-default ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-slate-600 sm:text-sm sm:leading-6">
+						<option value="wait">Wait</option>
+						<option value="continue">Continue</option>
+						<option value="panic">Panic</option>
+					</select>
+				</div>
+
+				<div class="mt-2 col-span-3 col-start-2 row-start-2">
+					<p :for="getIdKey('settings-pool-comment')" class="text-base text-default">Comment</p>
+					<input :id="getIdKey('settings-pool-comment')" v-model="poolConfig.comment"
+						name="setting-pool-comment" placeholder="Enter a comment here" type="text"
+						class="input-textlike mt-1 block w-full rounded-md border-0 py-1.5 px-1.5 text-default shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-muted focus:ring-2 focus:ring-inset focus:ring-slate-300 sm:text-sm sm:leading-6" />
+				</div>
+
+				<!-- auto-expand -->
+				<div class="col-span-1 col-start-1 row-start-3">
+					<PfSwitch v-model="poolConfig.properties.autoExpand"
+						:id="getIdKey('settings-pool-auto-expand')"
+						:disabled="settingsLocked"
+						label="Auto-Expand Pool" />
+				</div>
+
+				<!-- auto-replace -->
+				<div class="col-span-1 col-start-2 row-start-3">
+					<PfSwitch v-model="poolConfig.properties.autoReplace"
+						:id="getIdKey('settings-pool-auto-replace')"
+						:disabled="settingsLocked"
+						label="Auto-Replace Drives" />
+				</div>
+
+				<!-- display snapshots in filesystem list -->
+				<div class="col-span-2 col-start-3 row-start-3">
+					<PfSwitch v-model="poolConfig.properties.listSnapshots"
+						:id="getIdKey('settings-pool-display-snapshots')"
+						:disabled="settingsLocked"
+						label="List Snapshots With File Systems" />
+				</div>
+
+				<!-- delegation (Allow non-privileged user access based on the dataset permissions)-->
+				<div class="col-span-2 col-start-1 row-start-4">
+					<PfSwitch v-model="poolConfig.properties.delegation"
+						:id="getIdKey('settings-pool-delegation')"
+						:disabled="settingsLocked"
+						label="Delegation" />
+					<p class="text-xs text-muted mt-0.5">(Access based on dataset permissions)</p>
+				</div>
+
+				<!-- auto-trim -->
+				<div v-if="props.pool.diskType == 'SSD' || props.pool.diskType == 'Hybrid'"
+					class="col-span-1 col-start-3 row-start-4">
+					<PfSwitch v-model="poolConfig.properties.autoTrim"
+						:id="getIdKey('settings-pool-auto-trim')"
+						:disabled="settingsLocked"
+						label="Auto-TRIM Pool" />
+				</div>
+
 			</div>
+		</div>
 		<template #footer>
 			<div class="button-group-row w-full justify-between">
 				<div class="mt-2 justify-self-start">

--- a/zfs/src/components/pools/PoolListElement.vue
+++ b/zfs/src/components/pools/PoolListElement.vue
@@ -1,175 +1,65 @@
 <template>
-	<div class="">
-		<div class="">
-			<Disclosure v-slot="{ open }" :defaultOpen="false">
-				<DisclosureButton class="bg-default grid grid-cols-10 grid-flow-cols w-full justify-center text-center">
-					<div name="pool-chevron" class="py-1 mt-1 mr-2 col-span-1 ml-4 justify-self-start"
-						:title="poolData[props.poolIdx].name">
-						<ChevronUpIcon class="-mt-2 h-10 w-10 text-default transition-all duration-200 transform"
-							:class="{ 'rotate-90': !open, 'rotate-180': open, }" />
-					</div>
-					<div name="pool-name" class="py-1 mt-1 col-span-1 justify-start text-left flex flex-row"
-						:class="truncateText" :title="poolData[props.poolIdx].name">
-						{{ poolData[props.poolIdx].name}}
-						<div v-if="upgradeablePool"
-							title="Pool was made with a legacy version of ZFS. Upgrade available."
-							class="flex flex-row justify-between w-fit bg-default rounded-full items-center">
-							<ExclamationCircleIcon class="ml-2 w-5 text-orange-700" />
-						</div>
-					</div>
-					<div name="pool-status" class="py-1 mt-1 col-span-1 font-semibold"
-						:class="[formatStatus(poolData[props.poolIdx].status), truncateText]"
-						:title="poolData[props.poolIdx].status">{{ poolData[props.poolIdx].status }}</div>
-					<div name="pool-percentage" class="py-1 mt-1 col-span-1">
-						<div class="w-full bg-well rounded-full text-center"
-							:title="poolData[props.poolIdx].properties.capacity + '%'">
-							<div v-if="props.pool.properties.refreservationPercent!">
-								<div
-									class="w-full bg-well rounded-full h-4 mt-1 text-center relative flex overflow-hidden">
-									<div :class="capacityColor" class="h-4"
-										:style="{ width: `${props.pool.properties.capacity}%` }">
-										<div
-											class="absolute inset-0 flex items-center justify-center text-sm font-medium text-default p-0.5 leading-none">
-											{{ props.pool.properties.capacity }}%
-										</div>
-									</div>
-								</div>
-							</div>
-							<div v-else>
-								<div
-									class="w-full bg-well rounded-full h-4 mt-1 text-center relative flex overflow-hidden">
-									<div :class="capacityColor" class="h-4"
-										:style="{ width: `${props.pool.properties.capacity}%` }">
-										<div
-											class="absolute inset-0 flex items-center justify-center text-sm font-medium text-default p-0.5 leading-none">
-											{{ props.pool.properties.capacity }}%
-										</div>
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-					<div name="pool-used" class="py-1 mt-1 col-span-1" :class="truncateText"
-						:title="poolData[props.poolIdx].properties.allocated">{{
-						poolData[props.poolIdx].properties.allocated }}</div>
-					<div name="pool-available" class="py-1 mt-1 col-span-1" :class="truncateText"
-						:title="poolData[props.poolIdx].properties.available.toString()">{{ poolData[props.poolIdx].properties.available }}
-					</div>
-					<div name="pool-total" class="py-1 mt-1 col-span-1" :class="truncateText"
-						:title="poolData[props.poolIdx].properties.size">{{ poolData[props.poolIdx].properties.size }}
-					</div>
-					<div name="pool-message" class="py-1 -mt-1 col-span-2">
-						<Status :pool="poolData[props.poolIdx]" :isDisk="false" :isTrim="false" :isPoolList="true"
-							:isPoolDetail="false" :idKey="'scan-status-box'" ref="scanStatusBox" />
-					</div>
-					<div name="pool-menu" class="relative py-1 mt-1 p-3 text-right font-medium sm:pr-6 lg:pr-8">
-						<Menu as="div" class="relative inline-block text-right -mt-1">
-							<div>
-								<MenuButton @click.stop
-									class="flex items-center rounded-full bg-default p-2 hover:text-default focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 focus:ring-offset-gray-100">
-									<span class="sr-only">Open options</span>
-									<EllipsisVerticalIcon class="w-5" aria-hidden="true" />
-								</MenuButton>
-							</div>
-
-							<transition enter-active-class="transition ease-out duration-100"
-								enter-from-class="transform opacity-0 scale-95"
-								enter-to-class="transform opacity-100 scale-100"
-								leave-active-class="transition ease-in duration-75"
-								leave-from-class="transform opacity-100 scale-100"
-								leave-to-class="transform opacity-0 scale-95">
-								<MenuItems @click.stop
-									class="absolute right-0 z-10 w-max origin-top-right rounded-md bg-default shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-									<div class="py-1">
-										<MenuItem as="div" v-slot="{ active }" >
-										<a href="#" @click="showPoolModal(poolData[props.poolIdx])!"
-											:class="[active ? 'bg-accent text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Pool Details</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-										<a href="#" @click="clearPoolErrors(poolData[props.poolIdx].name)"
-											:class="[active ? 'bg-accent text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Clear Pool Errors</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-										<a v-if="upgradeablePool" href="#" @click="upgradeThisPool(props.pool)!"
-											:class="[active ? 'bg-orange-700 text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Upgrade Pool</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-										<a v-if="!scanActivity!.isActive" href="#" @click="resilverThisPool(props.pool)"
-											:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Resilver Pool</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-										<a v-if="!scanActivity!.isActive" href="#" @click="scrubThisPool(props.pool)"
-											:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Scrub Pool</a>
-										<a v-if="scanActivity!.isActive && scanActivity!.isPaused && scanOperation == 'SCRUB'"
-											href="#" @click="resumeScrub(props.pool)"
-											:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Resume Scrub</a>
-										<a v-if="scanActivity!.isActive && !scanActivity!.isPaused && scanOperation == 'SCRUB'"
-											href="#" @click="pauseScrub(props.pool)"
-											:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Pause Scrub</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-										<a v-if="scanActivity!.isActive && scanOperation == 'SCRUB'" href="#"
-											@click="stopScrub(props.pool)"
-											:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Cancel Scrub</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-										<a v-if="!trimActivity!.isActive && !trimActivity!.isPaused && poolData[props.poolIdx].diskType != 'HDD' && getIsTrimmable()"
-											href="#" @click="trimThisPool(poolData[props.poolIdx])"
-											:class="[active ? 'bg-accent text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											TRIM Pool</a>
-										<a v-if="trimActivity!.isPaused && poolData[props.poolIdx].diskType != 'HDD' && getIsTrimmable()"
-											href="#" @click="resumeTrim(poolData[props.poolIdx])"
-											:class="[active ? 'bg-accent text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Resume TRIM (Pool)</a>
-										<a v-if="trimActivity!.isActive && poolData[props.poolIdx].diskType != 'HDD' && getIsTrimmable()"
-											href="#" @click="pauseTrim(poolData[props.poolIdx])"
-											:class="[active ? 'bg-accent text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Pause TRIM (Pool)</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-										<a v-if="trimActivity!.isActive || trimActivity!.isPaused && poolData[props.poolIdx].diskType != 'HDD' && getIsTrimmable()"
-											href="#" @click="stopTrim(poolData[props.poolIdx])"
-											:class="[active ? 'bg-accent text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Cancel TRIM (Pool)</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-										<a href="#" @click="showAddVDev(poolData[props.poolIdx])"
-											:class="[active ? 'bg-accent text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Add Virtual Device</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-											<a href="#" @click="exportThisPool(poolData[props.poolIdx])"
-												:class="[active ? 'bg-accent text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Export Pool</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }" v-if="canDestructive">
-											<a href="#" @click="destroyPoolAndUpdate(poolData[props.poolIdx])"
-												:class="[active ? 'bg-danger text-default' : 'text-muted', 'block px-4 py-2 text-sm']">
-											Destroy Pool</a>
-										</MenuItem>
-									</div>
-								</MenuItems>
-							</transition>
-						</Menu>
-					</div>
-				</DisclosureButton>
-				<DisclosurePanel class="">
-					<div v-for="vDev, vDevIdx in poolData[props.poolIdx].vdevs" :key="vDevIdx" class="">
-						<VDevElement :pool="poolData[props.poolIdx]" :poolIdx="props.poolIdx" :vDev="vDev"
-							:vDevIdx="vDevIdx" ref="vDevElement" />
-					</div>
-				</DisclosurePanel>
-			</Disclosure>
-		</div>
-	</div>
+	<!-- PF expandable table row: main pool row -->
+	<tr class="pf-v5-c-table__tr bg-default" @click="isExpanded = !isExpanded" style="cursor: pointer;">
+		<td class="pf-v5-c-table__toggle">
+			<button class="pf-v5-c-button pf-m-plain" @click.stop="isExpanded = !isExpanded"
+				:aria-expanded="isExpanded" :title="poolData[props.poolIdx].name">
+				<svg class="pf-v5-c-table__toggle-icon" :style="{ transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }"
+					viewBox="0 0 256 512" fill="currentColor" aria-hidden="true" style="width:1em;height:1em;">
+					<path d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"/>
+				</svg>
+			</button>
+		</td>
+		<td class="pf-v5-c-table__td py-1 text-left" :class="truncateText" :title="poolData[props.poolIdx].name">
+			<span class="flex flex-row items-center">
+				{{ poolData[props.poolIdx].name }}
+				<span v-if="upgradeablePool"
+					title="Pool was made with a legacy version of ZFS. Upgrade available."
+					class="flex flex-row items-center ml-1">
+					<ExclamationCircleIcon class="w-5 text-orange-700" />
+				</span>
+			</span>
+		</td>
+		<td class="pf-v5-c-table__td py-1 font-semibold text-center"
+			:class="[formatStatus(poolData[props.poolIdx].status), truncateText]"
+			:title="poolData[props.poolIdx].status">{{ poolData[props.poolIdx].status }}</td>
+		<td class="pf-v5-c-table__td py-1 text-center">
+			<!-- PF Progress bar -->
+			<div class="pf-v5-c-progress" :class="{'pf-m-danger': Number(props.pool.properties.capacity) > 80}"
+				:title="props.pool.properties.capacity + '%'">
+				<div class="pf-v5-c-progress__description">{{ props.pool.properties.capacity }}%</div>
+				<div class="pf-v5-c-progress__bar" role="progressbar"
+					:aria-valuenow="Number(props.pool.properties.capacity)" aria-valuemin="0" aria-valuemax="100">
+					<div class="pf-v5-c-progress__indicator" :style="{ width: props.pool.properties.capacity + '%' }"></div>
+				</div>
+			</div>
+		</td>
+		<td class="pf-v5-c-table__td py-1 text-center" :class="truncateText"
+			:title="poolData[props.poolIdx].properties.allocated">{{
+			poolData[props.poolIdx].properties.allocated }}</td>
+		<td class="pf-v5-c-table__td py-1 text-center" :class="truncateText"
+			:title="poolData[props.poolIdx].properties.available.toString()">{{ poolData[props.poolIdx].properties.available }}
+		</td>
+		<td class="pf-v5-c-table__td py-1 text-center" :class="truncateText"
+			:title="poolData[props.poolIdx].properties.size">{{ poolData[props.poolIdx].properties.size }}
+		</td>
+		<td class="pf-v5-c-table__td py-1 text-center" @click.stop>
+			<Status :pool="poolData[props.poolIdx]" :isDisk="false" :isTrim="false" :isPoolList="true"
+				:isPoolDetail="false" :idKey="'scan-status-box'" ref="scanStatusBox" />
+		</td>
+		<td class="pf-v5-c-table__td py-1 text-right" @click.stop>
+			<PfDropdownMenu :items="poolMenuItems" :kebab="true" />
+		</td>
+	</tr>
+	<!-- PF expandable content row -->
+	<tr class="pf-v5-c-table__expandable-row" :class="{'pf-m-expanded': isExpanded}" v-if="isExpanded">
+		<td :colspan="9">
+			<div v-for="(vDev, vDevIdx) in poolData[props.poolIdx].vdevs" :key="vDevIdx">
+				<VDevElement :pool="poolData[props.poolIdx]" :poolIdx="props.poolIdx" :vDev="vDev"
+					:vDevIdx="vDevIdx" ref="vDevElement" />
+			</div>
+		</td>
+	</tr>
 
 	<div v-if="showPoolDetails">
 		<component :is="showPoolDetailsComponent" :showFlag="showPoolDetails" @close="updateShowPoolDetails"
@@ -245,13 +135,14 @@
 </template>
 <script setup lang="ts">
 import { ref, inject, Ref, provide, watch, computed, onMounted} from "vue";
-import { EllipsisVerticalIcon, ChevronUpIcon, ExclamationCircleIcon } from '@heroicons/vue/24/outline';
-import { Menu, MenuButton, MenuItem, MenuItems, Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
+import { ExclamationCircleIcon } from '@heroicons/vue/24/outline';
 import { destroyPool, trimPool, scrubPool, resilverPool, clearErrors, exportPool, upgradePool } from "../../composables/pools";
 import { labelClear } from "../../composables/disks";
 import { formatStatus, isPoolUpgradable, getCapacityColor  } from '../../composables/helpers';
 import VDevElement from "./VDevElement.vue";
 import Status from "../common/Status.vue";
+import PfDropdownMenu from "../pf/PfDropdownMenu.vue";
+import type { DropdownMenuItem } from "../pf/PfDropdownMenu.vue";
 import { ZPool, VDevDisk, ZFSFileSystemInfo } from "@45drives/houston-common-lib";
 import { pushNotification, Notification } from '@45drives/houston-common-ui';
 import { PoolScanObjectGroup, PoolDiskStats, ConfirmationCallback, Activity } from "../../types";
@@ -265,6 +156,62 @@ interface PoolListElementProps {
 const props = defineProps<PoolListElementProps>();
 const truncateText = inject<Ref<string>>('style-truncate-text')!;
 const canDestructive = inject<Ref<boolean>>('can-destructive')!;
+
+// PF expandable row state (replaces HeadlessUI Disclosure)
+const isExpanded = ref(false);
+
+// Computed menu items for PfDropdownMenu (replaces HeadlessUI Menu)
+const poolMenuItems = computed<DropdownMenuItem[]>(() => {
+	const items: DropdownMenuItem[] = [
+		{ label: 'Pool Details', action: () => showPoolModal(poolData.value[props.poolIdx]) },
+	];
+
+	if (canDestructive.value) {
+		items.push({ label: 'Clear Pool Errors', action: () => clearPoolErrors(poolData.value[props.poolIdx].name) });
+
+		if (upgradeablePool.value) {
+			items.push({ label: 'Upgrade Pool', action: () => upgradeThisPool(props.pool) });
+		}
+
+		if (!scanActivity.value?.isActive) {
+			items.push({ label: 'Resilver Pool', action: () => resilverThisPool(props.pool) });
+		}
+
+		// Scrub actions
+		if (!scanActivity.value?.isActive) {
+			items.push({ label: 'Scrub Pool', action: () => scrubThisPool(props.pool) });
+		}
+		if (scanActivity.value?.isActive && scanActivity.value?.isPaused && scanOperation.value == 'SCRUB') {
+			items.push({ label: 'Resume Scrub', action: () => resumeScrub(props.pool) });
+		}
+		if (scanActivity.value?.isActive && !scanActivity.value?.isPaused && scanOperation.value == 'SCRUB') {
+			items.push({ label: 'Pause Scrub', action: () => pauseScrub(props.pool) });
+		}
+		if (scanActivity.value?.isActive && scanOperation.value == 'SCRUB') {
+			items.push({ label: 'Cancel Scrub', action: () => stopScrub(props.pool) });
+		}
+
+		// TRIM actions
+		if (!trimActivity.value?.isActive && !trimActivity.value?.isPaused && poolData.value[props.poolIdx].diskType != 'HDD' && getIsTrimmable()) {
+			items.push({ label: 'TRIM Pool', action: () => trimThisPool(poolData.value[props.poolIdx]) });
+		}
+		if (trimActivity.value?.isPaused && poolData.value[props.poolIdx].diskType != 'HDD' && getIsTrimmable()) {
+			items.push({ label: 'Resume TRIM (Pool)', action: () => resumeTrim(poolData.value[props.poolIdx]) });
+		}
+		if (trimActivity.value?.isActive && poolData.value[props.poolIdx].diskType != 'HDD' && getIsTrimmable()) {
+			items.push({ label: 'Pause TRIM (Pool)', action: () => pauseTrim(poolData.value[props.poolIdx]) });
+		}
+		if ((trimActivity.value?.isActive || trimActivity.value?.isPaused) && poolData.value[props.poolIdx].diskType != 'HDD' && getIsTrimmable()) {
+			items.push({ label: 'Cancel TRIM (Pool)', action: () => stopTrim(poolData.value[props.poolIdx]) });
+		}
+
+		items.push({ label: 'Add Virtual Device', action: () => showAddVDev(poolData.value[props.poolIdx]) });
+		items.push({ label: 'Export Pool', action: () => exportThisPool(poolData.value[props.poolIdx]) });
+		items.push({ label: 'Destroy Pool', action: () => destroyPoolAndUpdate(poolData.value[props.poolIdx]) });
+	}
+
+	return items;
+});
 
 const selectedPool = ref<ZPool>();
 const selectedDisk = ref<VDevDisk>();

--- a/zfs/src/components/pools/PoolsList.vue
+++ b/zfs/src/components/pools/PoolsList.vue
@@ -1,23 +1,25 @@
 <template>
 	<div
 		class="inline-block min-w-full min-h-full py-4 align-middle sm:px-4 lg:px-6 overflow-visible bg-accent rounded-md border border-default">
-		<div
-			class="flex bg-well justify-between rounded-md p-2 shadow text-default rounded-b-md ring-1 ring-black ring-opacity-5">
-			<div v-if="canDestructive" class="button-group-row justify-start">
-				<button id="createPool" class="btn btn-primary" @click="newPoolWizardBtn">Create Storage Pool</button>
-				<button id="importPool" class="btn btn-secondary" @click="importNewPoolBtn">Import Storage Pool</button>
-			</div>
-			<div v-else class="button-group-row justify-start">
-				<button id="createPool" disabled :title="!canDestructive ? 'Requires administrative privileges' : ''"
-					class="btn btn-primary" @click="newPoolWizardBtn">Create Storage Pool</button>
-				<button id="importPool" disabled :title="!canDestructive ? 'Requires administrative privileges' : ''"
-					class="btn btn-secondary" @click="importNewPoolBtn">Import Storage
-					Pool</button>
-			</div>
-			<div class="button-group-row justify-end">
-				<button id="refreshPools" class="btn btn-secondary " @click="refreshAllData">
-					<ArrowPathIcon class="w-5 h-5 m-1" />
-				</button>
+		<!-- PF Toolbar -->
+		<div class="pf-v5-c-toolbar">
+			<div class="pf-v5-c-toolbar__content">
+				<div class="pf-v5-c-toolbar__group">
+					<button id="createPool" class="pf-v5-c-button pf-m-primary"
+						:disabled="!canDestructive"
+						:title="!canDestructive ? 'Requires administrative privileges' : ''"
+						@click="newPoolWizardBtn">Create Storage Pool</button>
+					<button id="importPool" class="pf-v5-c-button pf-m-secondary"
+						:disabled="!canDestructive"
+						:title="!canDestructive ? 'Requires administrative privileges' : ''"
+						@click="importNewPoolBtn">Import Storage Pool</button>
+				</div>
+				<div class="pf-v5-c-toolbar__item pf-m-pagination">
+					<button id="refreshPools" class="pf-v5-c-button pf-m-plain" aria-label="Refresh pools"
+						@click="refreshAllData">
+						<ArrowPathIcon class="w-5 h-5" />
+					</button>
+				</div>
 			</div>
 		</div>
 
@@ -25,41 +27,38 @@
 			<div class="inline-block min-w-full min-h-full shadow align-middle rounded-md border border-default">
 				<div class="whitespace-nowrap text-ellipsis ring-1 ring-black ring-opacity-5 rounded-md">
 
-					<table class="min-w-full divide-y divide-default rounded-md">
+					<table class="pf-v5-c-table pf-m-grid-md min-w-full divide-y divide-default rounded-md">
 						<thead class="rounded-md">
-							<tr class="bg-well rounded-t-md grid grid-cols-10">
-								<th class="relative py-2 rounded-tl-md col-span-1">
-									<span class="sr-only"></span>
+							<tr class="pf-v5-c-table__tr bg-well rounded-t-md">
+								<th class="pf-v5-c-table__th" style="width: 3rem;">
+									<span class="sr-only">Toggle</span>
 								</th>
-								<th class="py-2 font-semibold text-default col-span-1 flex flex-row justify-start"
+								<th class="pf-v5-c-table__th py-2 font-semibold text-default text-left"
 									:class="truncateText" title="Name">Name</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Status">Status</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Used (%)">Used (%)</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Used">Used</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Available">Available</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Total">Total</th>
-								<th class="py-2 font-semibold text-default col-span-2" :class="truncateText"
-									title="Message">Message</th>
-								<th class="relative py-2 sm:pr-6 lg:pr-8 rounded-tr-md col-span-1">
-									<span class="sr-only"></span>
+								<th class="pf-v5-c-table__th py-2 font-semibold text-default text-center"
+									:class="truncateText" title="Status">Status</th>
+								<th class="pf-v5-c-table__th py-2 font-semibold text-default text-center"
+									:class="truncateText" title="Used (%)">Used (%)</th>
+								<th class="pf-v5-c-table__th py-2 font-semibold text-default text-center"
+									:class="truncateText" title="Used">Used</th>
+								<th class="pf-v5-c-table__th py-2 font-semibold text-default text-center"
+									:class="truncateText" title="Available">Available</th>
+								<th class="pf-v5-c-table__th py-2 font-semibold text-default text-center"
+									:class="truncateText" title="Total">Total</th>
+								<th class="pf-v5-c-table__th py-2 font-semibold text-default text-center"
+									:class="truncateText" title="Message">Message</th>
+								<th class="pf-v5-c-table__th" style="width: 3rem;">
+									<span class="sr-only">Actions</span>
 								</th>
-
 							</tr>
 						</thead>
 
-						<tbody class="">
-							<tr class="border border-collapse border-default ">
-								<div v-if="poolData.length > 0 && poolsLoaded == true" class="">
-									<div v-for="pool, poolIdx in poolData" :key="poolIdx" class="">
-										<PoolListElement :poolIdx="poolIdx" :pool="pool" />
-									</div>
-								</div>
-							</tr>
+						<tbody class="pf-v5-c-table__tbody">
+							<template v-if="poolData.length > 0 && poolsLoaded == true">
+								<template v-for="(pool, poolIdx) in poolData" :key="poolIdx">
+									<PoolListElement :poolIdx="poolIdx" :pool="pool" />
+								</template>
+							</template>
 						</tbody>
 					</table>
 
@@ -67,8 +66,13 @@
 						<LoadingSpinner :width="'w-10'" :height="'h-10'" :baseColor="'text-gray-200'"
 							:fillColor="'fill-slate-500'" class="font-semibold text-lg my-0.5" />
 					</div>
-					<div v-if="poolData.length < 1 && poolsLoaded == true" class="p-2 flex bg-default justify-center ">
-						<span class="font-semibold text-lg my-2">No Pools Found</span>
+					<!-- PF EmptyState -->
+					<div v-if="poolData.length < 1 && poolsLoaded == true" class="pf-v5-c-empty-state">
+						<div class="pf-v5-c-empty-state__content">
+							<h2 class="pf-v5-c-empty-state__header">
+								<div class="pf-v5-c-empty-state__title-text">No Pools Found</div>
+							</h2>
+						</div>
 					</div>
 
 				</div>

--- a/zfs/src/components/pools/VDevElement.vue
+++ b/zfs/src/components/pools/VDevElement.vue
@@ -1,100 +1,59 @@
 <template>
-	<div class="">
-		<div class="">
-			<Disclosure v-slot="{ open }" :defaultOpen="true">
-				<DisclosureButton
-					class="grid grid-cols-8 grid-flow-cols w-full text-center bg-primary text-sm text-white">
-					<div name="vdev-chevron" class="p-1 mt-1 col-span-1 flex flex-row justify-center text-center">
-						<ChevronUpIcon class="-mt-2 h-10 w-10 text-white transition-all duration-200 transform"
-							:class="{ 'rotate-90': !open, 'rotate-180': open, }" />
-					</div>
-					<div name="vdev-name" class="p-1 mt-1 col-span-1 text-base text-left" :class="truncateText"
-						:title="props.vDev.name">{{ props.vDev.name }}</div>
-					<div name="vdev-status" class="p-1 mt-1 col-span-1 font-semibold text-base"
-						:class="[formatStatus(props.vDev.status), truncateText]" :title="props.vDev.status">{{
-						props.vDev.status }}</div>
-					<div name="vdev-type" class="p-1 mt-1 col-span-1 text-base" :class="truncateText"
-						:title="upperCaseWord(props.vDev.type) + ' Device'">{{ upperCaseWord(props.vDev.type) }} Device
-					</div>
-					<div name="vdev-read-err" class="p-1 mt-1 col-span-1 text-base" :class="truncateText"
-						:title="props.vDev.stats!.read_errors + ' Read Errors'">{{ props.vDev.stats!.read_errors }} Read
-						Errors</div>
-					<div name="vdev-write-err" class="p-1 mt-1 col-span-1 text-base" :class="truncateText"
-						:title="props.vDev.stats!.write_errors + ' Write Errors'">{{ props.vDev.stats!.write_errors }}
-						Write Errors</div>
-					<div name="vdev-checksum-err" class="p-1 mt-1 col-span-1 text-base" :class="truncateText"
-						:title="props.vDev.stats!.checksum_errors + ' Checksum Errors'">{{
-						props.vDev.stats!.checksum_errors }} Checksum Errors</div>
-					<div name="vdev-menu"
-						class="col-span-1 relative p-1 pl-3 pr-4 text-right font-medium sm:pr-6 lg:pr-8 justify-self-end justify-items-end">
-						<Menu as="div" class="relative inline-block text-right">
-							<div>
-								<MenuButton @click.stop :disabled="!canDestructive" :aria-disabled="!canDestructive"
-									:title="!canDestructive ? 'Requires administrative privileges' : ''" :class="[
-										'flex items-center rounded-full p-2 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 focus:ring-offset-gray-100',
-										canDestructive ? 'bg-primary hover:text-white cursor-pointer'
-											: 'bg-primary/60 text-muted cursor-not-allowed'
-									]">
-									<span class="sr-only">Open options</span>
-									<EllipsisVerticalIcon class="w-5" aria-hidden="true" />
-								</MenuButton>
-							</div>
-
-							<transition enter-active-class="transition ease-out duration-100"
-								enter-from-class="transform opacity-0 scale-95"
-								enter-to-class="transform opacity-100 scale-100"
-								leave-active-class="transition ease-in duration-75"
-								leave-from-class="transform opacity-100 scale-100"
-								leave-to-class="transform opacity-0 scale-95">
-								<MenuItems @click.stop
-									class="absolute right-0 z-10 w-max origin-top-right rounded-md bg-primary shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-									<div class="py-1">
-										<!-- <MenuItem as="div" v-slot="{ active }">
-											<a href="#" @click.stop="clearVDevErrors(props.pool.name, props.vDev.name)" :class="[active ? 'bg-primary text-white' : 'text-white', 'block px-4 py-2 text-sm']">Clear Virtual Device Errors</a>
-										</MenuItem> -->
-										<MenuItem
-											v-if="pool.vdevs.length !== 1 && vDev !== pool.vdevs[0] && !vDev.type.includes('raid')"
-											as="div" v-slot="{ active }">
-										<a href="#" @click="removeVDev(props.pool, props.pool.vdevs[vDevIdx])"
-											:class="[active ? 'bg-danger text-white' : 'text-white', 'block px-4 py-2 text-sm']">Remove
-											Virtual Device</a>
-										</MenuItem>
-										<MenuItem as="div" v-slot="{ active }">
-										<a href="#" @click="showAttachDisk(props.pool, props.vDev)"
-											:class="[active ? 'bg-primary text-white' : 'text-white', 'block px-4 py-2 text-sm']">Attach
-											Disk</a>
-										</MenuItem>
-									</div>
-								</MenuItems>
-							</transition>
-						</Menu>
-					</div>
-				</DisclosureButton>
-				<DisclosurePanel>
-					<table class="min-w-full bg-secondary text-default">
-						<thead>
-							<tr :key="props.vDevIdx" class=" grid grid-cols-9 font-semibold text-white">
-								<!-- <th class="relative py-2 pl-3 pr-4 sm:pr-6 lg:pr-8 col-span-1">
-									<span class="sr-only"></span>
-								</th> -->
-								<th class="py-2 col-span-2" :class="truncateText" title="Disk">Disk</th>
-								<th class="py-2 col-span-1" :class="truncateText" title="State">State</th>
-								<th class="py-2 col-span-1" :class="truncateText" title="Type">Type</th>
-								<th class="py-2 col-span-1" :class="truncateText" title="Temperature">Temperature</th>
-								<th class="py-2 col-span-1" :class="truncateText" title="Capacity">Capacity</th>
-								<th class="py-2 col-span-2" :class="truncateText" title="Message">Message</th>
-								<th class="relative py-2 pl-3 pr-4 sm:pr-6 lg:pr-8 col-span-1">
-									<span class="sr-only"></span>
-								</th>
-							</tr>
-						</thead>
-					</table>
-					<div v-for="disk, diskIdx in props.vDev.disks" :key="diskIdx" class="">
-						<DiskElement :pool="poolData[props.poolIdx]" :poolIdx="props.poolIdx" :vDev="props.vDev"
-							:vDevIdx="props.vDevIdx" :disk="disk" :diskIdx="diskIdx" ref="diskElement" />
-					</div>
-				</DisclosurePanel>
-			</Disclosure>
+	<div>
+		<!-- VDev header row (compound expandable) -->
+		<div class="flex w-full text-center bg-primary text-sm text-white items-center" style="cursor: pointer;" @click="isExpanded = !isExpanded">
+			<div class="p-1 flex-none" style="width:3rem;">
+				<button class="pf-v5-c-button pf-m-plain text-white" @click.stop="isExpanded = !isExpanded"
+					:aria-expanded="isExpanded">
+					<svg :style="{ transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }"
+						viewBox="0 0 256 512" fill="currentColor" aria-hidden="true" style="width:1em;height:1em;">
+						<path d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"/>
+					</svg>
+				</button>
+			</div>
+			<div class="p-1 flex-1 text-base text-left" :class="truncateText"
+				:title="props.vDev.name">{{ props.vDev.name }}</div>
+			<div class="p-1 flex-1 font-semibold text-base"
+				:class="[formatStatus(props.vDev.status), truncateText]" :title="props.vDev.status">{{
+				props.vDev.status }}</div>
+			<div class="p-1 flex-1 text-base" :class="truncateText"
+				:title="upperCaseWord(props.vDev.type) + ' Device'">{{ upperCaseWord(props.vDev.type) }} Device
+			</div>
+			<div class="p-1 flex-1 text-base" :class="truncateText"
+				:title="props.vDev.stats!.read_errors + ' Read Errors'">{{ props.vDev.stats!.read_errors }} Read
+				Errors</div>
+			<div class="p-1 flex-1 text-base" :class="truncateText"
+				:title="props.vDev.stats!.write_errors + ' Write Errors'">{{ props.vDev.stats!.write_errors }}
+				Write Errors</div>
+			<div class="p-1 flex-1 text-base" :class="truncateText"
+				:title="props.vDev.stats!.checksum_errors + ' Checksum Errors'">{{
+				props.vDev.stats!.checksum_errors }} Checksum Errors</div>
+			<div class="p-1 flex-none text-right pr-4" style="width:3rem;" @click.stop>
+				<PfDropdownMenu :items="vdevMenuItems" :kebab="true" />
+			</div>
+		</div>
+		<!-- VDev expanded content -->
+		<div v-if="isExpanded">
+			<table class="min-w-full bg-secondary text-default">
+				<thead>
+					<tr :key="props.vDevIdx" class="pf-v5-c-table__tr font-semibold text-white">
+						<th class="pf-v5-c-table__th py-2" :class="truncateText" title="Disk" style="width:22%;">Disk</th>
+						<th class="pf-v5-c-table__th py-2" :class="truncateText" title="State">State</th>
+						<th class="pf-v5-c-table__th py-2" :class="truncateText" title="Type">Type</th>
+						<th class="pf-v5-c-table__th py-2" :class="truncateText" title="Temperature">Temperature</th>
+						<th class="pf-v5-c-table__th py-2" :class="truncateText" title="Capacity">Capacity</th>
+						<th class="pf-v5-c-table__th py-2" :class="truncateText" title="Message" style="width:22%;">Message</th>
+						<th class="pf-v5-c-table__th py-2" style="width:3rem;">
+							<span class="sr-only">Actions</span>
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					<DiskElement v-for="(disk, diskIdx) in props.vDev.disks" :key="diskIdx"
+						:pool="poolData[props.poolIdx]" :poolIdx="props.poolIdx" :vDev="props.vDev"
+						:vDevIdx="props.vDevIdx" :disk="disk" :diskIdx="diskIdx" ref="diskElement" />
+				</tbody>
+			</table>
 		</div>
 	</div>
 	<div v-if="showAttachDiskModal">
@@ -110,12 +69,12 @@
 
 </template>
 <script setup lang="ts">
-import { ref, inject, Ref, watch, provide, onMounted } from "vue";
-import { EllipsisVerticalIcon, ChevronUpIcon } from '@heroicons/vue/24/outline';
-import { Menu, MenuButton, MenuItem, MenuItems, Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
+import { ref, inject, Ref, watch, provide, onMounted, computed } from "vue";
 import { clearErrors, removeVDevFromPool, setRefreservation } from "../../composables/pools";
 import { formatStatus, upperCaseWord,  } from '../../composables/helpers';
 import DiskElement from '../pools/DiskElement.vue';
+import PfDropdownMenu from "../pf/PfDropdownMenu.vue";
+import type { DropdownMenuItem } from "../pf/PfDropdownMenu.vue";
 import { ZPool, VDev, VDevDisk, ZFSFileSystemInfo } from "@45drives/houston-common-lib";
 import { pushNotification, Notification } from '@45drives/houston-common-ui';
 import { Activity, PoolScanObjectGroup, PoolDiskStats, ConfirmationCallback } from "../../types";
@@ -137,6 +96,25 @@ const selectedPool = ref<ZPool>();
 const selectedVDev = ref<VDev>();
 
 const operationRunning = ref(false);
+
+// PF expandable state (replaces HeadlessUI Disclosure)
+const isExpanded = ref(true);
+
+// Computed menu items for PfDropdownMenu (replaces HeadlessUI Menu)
+const vdevMenuItems = computed<DropdownMenuItem[]>(() => {
+	const items: DropdownMenuItem[] = [];
+
+	if (canDestructive.value) {
+		if (props.pool.vdevs.length !== 1 && props.vDev !== props.pool.vdevs[0] && !props.vDev.type.includes('raid')) {
+			items.push({ label: 'Remove Virtual Device', action: () => removeVDev(props.pool, props.pool.vdevs[props.vDevIdx]) });
+		}
+		items.push({ label: 'Attach Disk', action: () => showAttachDisk(props.pool, props.vDev) });
+	} else {
+		items.push({ label: 'Attach Disk', action: () => showAttachDisk(props.pool, props.vDev), disabled: true, tooltip: 'Requires administrative privileges' });
+	}
+
+	return items;
+});
 
 
 /////////////// Loading/Refreshing //////////////////


### PR DESCRIPTION
## Summary

- Fix invalid `<div>` inside `<tbody>` with `<template>` wrappers
- Replace `grid grid-cols-*` table rows with semantic `<tr>/<td>`
- Add PF Toolbar for Create/Import/Refresh actions
- Add PF EmptyState for "No Pools Found"
- PF expandable table rows for pool/vdev/disk hierarchy
- PF Progress bar for capacity display
- Migrate all HeadlessUI `Menu` → `PfDropdownMenu` (5 components)
- Migrate all HeadlessUI `Switch` → `PfSwitch` (5 components)
- Migrate all `OldModal` → `PfModal` (4 modals)
- Net -567 lines of code

Closes #50

## Test plan

- [ ] Pools table renders with both test pools
- [ ] Expand/collapse pool rows works
- [ ] Kebab menu opens with correct actions
- [ ] Dashboard pool cards render correctly
- [ ] Create/Import buttons visible in toolbar
- [ ] "No Pools Found" empty state displays correctly
- [ ] All modals (PoolDetail, ImportPool, AttachDisk, ReplaceDisk) open/close correctly
- [ ] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)