### PR TITLE
Issue E (#51): File Systems page — PF tables, modals, dropdowns

### DIFF
--- a/zfs/src/components/file-systems/ChangePassphrase.vue
+++ b/zfs/src/components/file-systems/ChangePassphrase.vue
@@ -1,46 +1,42 @@
 <template>
-    <OldModal :isOpen="showChangePassphrase" @close="showChangePassphrase = false" :marginTop="'mt-28'" :width="'w-96'" :minWidth="'min-w-min'" :closeOnBackgroundClick ="false">
-        <template v-slot:title>
-            <legend class="flex justify-center">Change Passphrase</legend>
-        </template>
-        <template v-slot:content>
+    <PfModal :isOpen="showChangePassphrase" @close="showChangePassphrase = false" title="Change Passphrase">
+        <div>
             <div>
-                <div>
-                    <div class="flex flex-row justify-between items-center">
-                        <label :for="getIdKey('passphrase')"
-                            class="mt-1 block text-sm font-medium leading-6 text-default">New Passphrase</label>
-                        <span title="Passphrase requires at least 8 characters.">
-                            <InformationCircleIcon class="ml-2 mt-1 h-6 text-muted" />
-                        </span>
-                    </div>
-
-                    <input :id="getIdKey('passphrase')" type="password" v-model="passphrase" name="passphrase"
-                        class="mt-1 block w-full input-textlike bg-default" placeholder="Passphrase" />
+                <div class="flex flex-row justify-between items-center">
+                    <label :for="getIdKey('passphrase')"
+                        class="mt-1 block text-sm font-medium leading-6 text-default">New Passphrase</label>
+                    <span title="Passphrase requires at least 8 characters.">
+                        <InformationCircleIcon class="ml-2 mt-1 h-6 text-muted" />
+                    </span>
                 </div>
 
-                <div>
-                    <div class="flex flex-row justify-between items-center">
-                        <label :for="getIdKey('passphrase-confirm')"
-                            class="mt-1 block text-sm font-medium leading-6 text-default">Confirm New Passphrase</label>
-                        <span title="Passphrase requires at least 8 characters.">
-                            <InformationCircleIcon class="ml-2 mt-1 h-6 text-muted" />
-                        </span>
-                    </div>
-
-                    <input :id="getIdKey('passphrase-confirm')" type="password" @keydown.enter="changeBtn()"
-                        v-model="passphraseConfirm" name="passphrase-confirm"
-                        class="mt-1 block w-full input-textlike bg-default" placeholder="Confirm Passphrase" />
-                </div>
-
-                <!-- Important Passphrase Reminder -->
-                <div class="my-2 p-2 text-danger text-sm">
-                    <p><strong>Important:</strong> Please note your passphrase carefully. If it is lost, it
-                        cannot
-                        be retrieved or reset.</p>
-                </div>
+                <input :id="getIdKey('passphrase')" type="password" v-model="passphrase" name="passphrase"
+                    class="mt-1 block w-full input-textlike bg-default" placeholder="Passphrase" />
             </div>
-        </template>
-        <template v-slot:footer>
+
+            <div>
+                <div class="flex flex-row justify-between items-center">
+                    <label :for="getIdKey('passphrase-confirm')"
+                        class="mt-1 block text-sm font-medium leading-6 text-default">Confirm New Passphrase</label>
+                    <span title="Passphrase requires at least 8 characters.">
+                        <InformationCircleIcon class="ml-2 mt-1 h-6 text-muted" />
+                    </span>
+                </div>
+
+                <input :id="getIdKey('passphrase-confirm')" type="password" @keydown.enter="changeBtn()"
+                    v-model="passphraseConfirm" name="passphrase-confirm"
+                    class="mt-1 block w-full input-textlike bg-default" placeholder="Confirm Passphrase" />
+            </div>
+
+            <!-- Important Passphrase Reminder -->
+            <div class="my-2 p-2 text-danger text-sm">
+                <p><strong>Important:</strong> Please note your passphrase carefully. If it is lost, it
+                    cannot
+                    be retrieved or reset.</p>
+            </div>
+        </div>
+
+        <template #footer>
             <div class="w-full grid grid-rows-2">
                 <div class="w-full row-start-1">
                     <div class="button-group-row mt-2 justify-self-center">
@@ -70,11 +66,11 @@
                 </div>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 </template>
 <script setup lang="ts">
 import { ref, Ref, inject } from 'vue';
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
 import { changePassphrase } from '../../composables/datasets';
 import { InformationCircleIcon } from '@heroicons/vue/24/solid';
 import { ZFSFileSystemInfo } from '@45drives/houston-common-lib';

--- a/zfs/src/components/file-systems/FileSystemConfigModal.vue
+++ b/zfs/src/components/file-systems/FileSystemConfigModal.vue
@@ -1,215 +1,199 @@
 <template>
-    <OldModal :isOpen="showFSConfig" @close="showFSConfig = false" :marginTop="'mt-28'" :width="'w-3/5'" :minWidth="'min-w-3/5'" :closeOnBackgroundClick="false">
-        <template v-slot:title>
-            <legend class="flex justify-center">Configure File System</legend>
-        </template>
-        <template v-slot:content>
-            <div>
-                <div class="grid grid-cols-4 gap-2">
-                    <div class="mt-2 ">
-                        <label :for="getIdKey('fs-config-name')" name="fs-config-name" class="mt-1 block text-sm leading-6 text-default">File System Name</label>
-                        <p :class="truncateText" :title="props.filesystem.name">{{ props.filesystem.name }}</p>
-                    </div>
-                    <div class="mt-2">
-                        <label :for="getIdKey('fs-config-guid')" name="fs-config-guid" class="mt-1 block text-sm leading-6 text-default">GUID</label>
-                        <p>{{ props.filesystem.properties.guid }}</p>
-                    </div>
-                    <div class="mt-2">
-                        <label :for="getIdKey('fs-config-case-sensitivity')" name="fs-config-case-sensitivity" class="mt-1 block text-sm leading-6 text-default">Case Sensitivity</label>
-                        <p>{{ upperCaseWord(props.filesystem.properties.caseSensitivity) }}</p>
-                    </div>
-                    <div class="mt-2">
-                        <label for="fs-config-readonly" :id="getIdKey('fs-config-readonly')" name="fs-config-readonly" class="mt-1 block text-sm leading-6 text-default">Read Only</label>
-                        <Switch v-model="fileSystemConfig.properties.isReadOnly" :id="getIdKey('fs-config-readonly')" :class="[fileSystemConfig.properties.isReadOnly! ? 'bg-secondary' : 'bg-accent', 'mt-1 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span :class="[fileSystemConfig.properties.isReadOnly! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span :class="[fileSystemConfig.properties.isReadOnly! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span :class="[fileSystemConfig.properties.isReadOnly! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
-                    </div>
-                </div>
-
-                <div class="mt-2">
-                    <label :for="getIdKey('fs-config-mountpoint')" name="fs-config-mountpoint" class="mt-1 block text-sm leading-6 text-default">Mountpoint</label>
-                    <input type="text" v-model="fileSystemConfig.mountpoint" name="fs-config-mountpoint" :id="getIdKey('fs-config-mountpoint')" class="mt-1 block w-full input-textlike bg-default" placeholder="Mountpoint" />
+    <PfModal :isOpen="showFSConfig" @close="showFSConfig = false" title="Configure File System">
+        <div>
+            <div class="grid grid-cols-4 gap-2">
+                <div class="mt-2 ">
+                    <label :for="getIdKey('fs-config-name')" name="fs-config-name" class="mt-1 block text-sm leading-6 text-default">File System Name</label>
+                    <p :class="truncateText" :title="props.filesystem.name">{{ props.filesystem.name }}</p>
                 </div>
                 <div class="mt-2">
-                    <label :for="getIdKey('fs-config-can-mount')" class="bg-default block text-base leading-6 text-default">Can Mount</label>
-                    <select :id="getIdKey('fs-config-can-mount')" v-model="fileSystemConfig.properties.canMount" name="fs-config-can-mount" class="mt-1 block w-full input-textlike bg-default">
-                        <option value="on">On</option>
-                        <option value="off">Off</option>
-                        <option value="noauto">No Auto</option>
-                    </select>
-                </div>
-
-                <div class="mt-2">
-                    <label :for="getIdKey('fs-config-quota')" class="mb-1 block text-sm font-medium leading-6 text-default">Quota</label>
-                    <div class="flex flex-row">
-                        <input v-model="fileSystemConfig.properties.quota.raw" :id="getIdKey('fs-config-quota-amount')" name="fs-config-quota-slider" type="range" min="0" max="1000" step="1" class="text-default mt-5 w-3/4 h-2 bg-accent rounded-lg appearance-none cursor-pointer " />
-                        <input v-model="fileSystemConfig.properties.quota.raw" type="number" name="fs-config-quota-num" :id="getIdKey('fs-config-quota-num')" min="0" max="1000" class="text-default bg-default mt-1 w-fit block py-1.5 px-1.5 ml-1 text-default placeholder:text-muted input-textlike sm:text-sm sm:leading-6" />
-                        <select v-model="fileSystemConfig.properties.quota.unit" :id="getIdKey('fs-config-quota-size')" name="fs-config-quota-size" class="block sm:col-span-1 bg-default py-1.5 pl-3 pr-10 text-default input-textlike sm:text-sm sm:leading-6">
-                            <option value="kib">KiB</option>
-                            <option value="mib">MiB</option>
-                            <option value="gib">GiB</option>
-                            <option value="tib">TiB</option>
-                        </select>
-                    </div>
-                    <div class="flex flex-row justify-between">
-                        <div v-if="fileSystemConfig.properties.quota.raw !== null" class="mt-2 justify-self-start">
-                            <p class="text-muted">Used Space: {{ convertBytesToSize(fileSystemConfig.properties.used!) }}</p>
-                        </div>
-                        <div v-if="fileSystemConfig.properties.quota.raw === null || !fileSystemConfig.properties.quota.raw" class="mt-2 justify-self-end">
-                            <p class="text-muted">There is no quota currently set.</p>
-                        </div>
-                    </div>
-
-                </div>
-
-                <div class="mt-2">
-                    <label :for="getIdKey('fs-config-recordsize')" class="block text-sm font-medium leading-6 text-default">Record Size</label>
-                    <select :id="getIdKey('fs-config-recordsize')" v-model="fileSystemConfig.properties.recordSize" name="fs-config-recordsize" class="mt-1 block w-full input-textlike bg-default">
-                        <option value="512">512 B</option>
-                        <option value="4K">4 KiB</option>
-                        <option value="8K">8 KiB</option>
-                        <option value="16K">16 KiB</option>
-                        <option value="32K">32 KiB</option>
-                        <option value="64K">64 KiB</option>
-                        <option value="128K">128 KiB</option>
-                        <option value="256K">256 KiB</option>
-                        <option value="512K">512 KiB</option>
-                        <option value="1M">1 MiB</option>
-                    </select>
-                </div>
-
-                <div class="mt-2">
-                    <label :for="getIdKey('fs-config-refreservation')" class="mb-1 block text-sm font-medium leading-6 text-default">Refreservation</label>
-                    <div class="flex flex-row">
-                        <input v-model="fileSystemConfig.properties.refreservation!.raw" :id="getIdKey('fs-config-refreservation-amount')" name="fs-config-refreservation-slider" type="range" min="0" max="1000" step="1" class="text-default mt-5 w-3/4 h-2 bg-accent rounded-lg appearance-none cursor-pointer " />
-                        <input v-model="fileSystemConfig.properties.refreservation!.raw" type="number" name="fs-config-refreservation-num" :id="getIdKey('fs-config-refreservation-num')" min="0" max="1000" class="text-default bg-default mt-1 w-fit block py-1.5 px-1.5 ml-1 text-default placeholder:text-muted input-textlike sm:text-sm sm:leading-6" />
-                        <select v-model="fileSystemConfig.properties.refreservation!.unit" :id="getIdKey('fs-config-refreservation-size')" name="fs-config-refreservation-size" class="block sm:col-span-1 bg-default py-1.5 pl-3 pr-10 text-default input-textlike sm:text-sm sm:leading-6">
-                            <option value="kib">KiB</option>
-                            <option value="mib">MiB</option>
-                            <option value="gib">GiB</option>
-                            <option value="tib">TiB</option>
-                        </select>
-                    </div>
-                    <div class="flex flex-row justify-between">
-
-                        <div v-if="fileSystemConfig.properties.refreservation!.raw !== null" class="mt-2 justify-self-start">
-                            <p class="text-muted">Available Space: {{ convertBytesToSize(fileSystemConfig.properties.available) }}</p>
-                        </div>
-                        <div v-if="fileSystemConfig.properties.refreservation!.raw === null || !fileSystemConfig.properties.refreservation!.raw" class="mt-2 justify-self-end">
-                            <p class="text-muted">There is no refreservation currently set.</p>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="mt-2">
-                    <label :for="getIdKey('fs-config-acl-inherit')" class="bg-default block text-base leading-6 text-default">ACL Inheritance</label>
-                    <select :id="getIdKey('fs-config-acl-inherit')" v-model="fileSystemConfig.properties.aclInheritance" name="fs-config-acl-inherit" class="mt-1 block w-full input-textlike bg-default">
-                        <option value="discard">Discard</option>
-                        <option value="noallow">No Allow</option>
-                        <option value="restricted">Restricted</option>
-                        <option value="passthrough">Passthrough</option>
-                        <option value="passthrough-x">Passthrough-X</option>
-                    </select>
+                    <label :for="getIdKey('fs-config-guid')" name="fs-config-guid" class="mt-1 block text-sm leading-6 text-default">GUID</label>
+                    <p>{{ props.filesystem.properties.guid }}</p>
                 </div>
                 <div class="mt-2">
-                    <label :for="getIdKey('fs-config-acl-type')" class="bg-default block text-base leading-6 text-default">ACL Type</label>
-                    <select :id="getIdKey('fs-config-acl-type')" v-model="fileSystemConfig.properties.aclType" name="fs-config-acl-type" class="mt-1 block w-full input-textlike bg-default">
-                        <option value="off">Off/No ACL</option>
-                        <option value="posix">POSIX ACL</option>
-                    </select>
+                    <label :for="getIdKey('fs-config-case-sensitivity')" name="fs-config-case-sensitivity" class="mt-1 block text-sm leading-6 text-default">Case Sensitivity</label>
+                    <p>{{ upperCaseWord(props.filesystem.properties.caseSensitivity) }}</p>
                 </div>
                 <div class="mt-2">
-                    <label :for="getIdKey('fs-config-access-time')" class="bg-default block text-base leading-6 text-default">Access Time</label>
-                    <select :id="getIdKey('fs-config-access-time')" v-model="fileSystemConfig.properties.accessTime" name="fs-config-access-time" class="mt-1 block w-full input-textlike bg-default">
-                        <option value="on">On</option>
-                        <option value="off">Off</option>
-                    </select>
-                </div>
-                <div class="mt-2">
-                    <label :for="getIdKey('fs-config-dedup')" class="bg-default block text-base leading-6 text-default">Deduplication</label>
-                    <select :id="getIdKey('fs-config-dedup')" v-model="fileSystemConfig.properties.deduplication" name="fs-config-dedup" class="mt-1 block w-full input-textlike bg-default">
-                        <option value="on">On</option>
-                        <option value="off">Off</option>
-                        <option value="edonr,verify">Edon-R + Verify</option>
-                        <option value="sha256">SHA-256</option>
-                        <option value="sha256,verify">SHA-256 + Verify</option>
-                        <option value="sha512">SHA-512</option>
-                        <option value="sha512,verify">SHA-512 + Verify</option>
-                        <option value="skein">Skein</option>
-                        <option value="skein,verify">Skein + Verify</option>
-                        <option value="verify">Verify</option>
-                    </select>
-                </div>
-
-                <div class="mt-2">
-                    <label :for="getIdKey('fs-config-compression')" class="bg-default block text-base leading-6 text-default">Compression</label>
-                    <select :id="getIdKey('fs-config-compression')" v-model="fileSystemConfig.properties.compression" name="fs-config-compression" class="mt-1 block w-full input-textlike bg-default">
-                        <option value="on">On</option>
-                        <option value="off">Off</option>
-                        <option value="gzip">GZIP</option>
-                        <option value="lz4">LZ4</option>
-                        <option value="lzjb">LZJB</option>
-                        <option value="zle">ZLE</option>
-                    </select>
-                </div>
-                <div class="mt-2">
-                    <label :for="getIdKey('fs-config-checksum')" class="bg-default block text-base leading-6 text-default">Checksum</label>
-                    <select :id="getIdKey('fs-config-checksum')" v-model="fileSystemConfig.properties.checksum" name="fs-config-checksum" class="mt-1 block w-full input-textlike bg-default">
-                        <option value="on">On</option>
-                        <option value="off">Off</option>
-                        <option value="edonr">Edon-R</option>
-                        <option value="fletcher2">Fletcher2</option>
-                        <option value="fletcher4">Fletcher4</option>
-                        <option value="noparity">No Parity</option>
-                        <option value="sha256">SHA-256</option>
-                        <option value="sha512">SHA-512</option>
-                        <option value="skein">Skein</option>
-                    </select>
-                </div>
-
-                <div class="mt-2">
-                    <label :for="getIdKey('fs-config-dnode-size')" class="bg-default block text-base leading-6 text-default">DNode Size</label>
-                    <select :id="getIdKey('fs-config-dnode-size')" v-model="fileSystemConfig.properties.dNodeSize" name="fs-config-dnode-size" class="mt-1 block w-full input-textlike bg-default">
-                        <option value="1k">1 KiB</option>
-                        <option value="2k">2 KiB</option>
-                        <option value="4k">4 KiB</option>
-                        <option value="8k">8 KiB</option>
-                        <option value="16k">16 KiB</option>
-                        <option value="auto">Auto</option>
-                        <option value="legacy">Legacy</option>
-                    </select>
-                </div>
-
-                <div class="mt-2">
-                    <label :for="getIdKey('fs-config-xattr')" class="bg-default block text-base leading-6 text-default">Extended Attributes</label>
-                    <select :id="getIdKey('fs-config-xattr')" v-model="fileSystemConfig.properties.extendedAttributes" name="fs-config-xattr" class="mt-1 block w-full input-textlike bg-default">
-                        <option value="on">On</option>
-                        <option value="off">Off</option>
-                        <option value="sa">System Attribute</option>
-                    </select>
-                </div>
-
-                <div v-if="props.filesystem.encrypted" class="mt-2">
-                    <label :for="getIdKey('fs-config-encryption')" name="fs-config-encryption" class="bg-default block text-base leading-6 text-default">Encryption</label>
-                    <p class="mt-1 block w-full bg-default">{{ props.filesystem.properties.encryption.toUpperCase() }}</p>
+                    <label for="fs-config-readonly" :id="getIdKey('fs-config-readonly')" name="fs-config-readonly" class="mt-1 block text-sm leading-6 text-default">Read Only</label>
+                    <PfSwitch
+                        :modelValue="fileSystemConfig.properties.isReadOnly!"
+                        @update:modelValue="fileSystemConfig.properties.isReadOnly = $event"
+                        :id="getIdKey('fs-config-readonly')"
+                    />
                 </div>
             </div>
 
-        </template>
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-mountpoint')" name="fs-config-mountpoint" class="mt-1 block text-sm leading-6 text-default">Mountpoint</label>
+                <input type="text" v-model="fileSystemConfig.mountpoint" name="fs-config-mountpoint" :id="getIdKey('fs-config-mountpoint')" class="mt-1 block w-full input-textlike bg-default" placeholder="Mountpoint" />
+            </div>
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-can-mount')" class="bg-default block text-base leading-6 text-default">Can Mount</label>
+                <select :id="getIdKey('fs-config-can-mount')" v-model="fileSystemConfig.properties.canMount" name="fs-config-can-mount" class="mt-1 block w-full input-textlike bg-default">
+                    <option value="on">On</option>
+                    <option value="off">Off</option>
+                    <option value="noauto">No Auto</option>
+                </select>
+            </div>
 
-        <template v-slot:footer>
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-quota')" class="mb-1 block text-sm font-medium leading-6 text-default">Quota</label>
+                <div class="flex flex-row">
+                    <input v-model="fileSystemConfig.properties.quota.raw" :id="getIdKey('fs-config-quota-amount')" name="fs-config-quota-slider" type="range" min="0" max="1000" step="1" class="text-default mt-5 w-3/4 h-2 bg-accent rounded-lg appearance-none cursor-pointer " />
+                    <input v-model="fileSystemConfig.properties.quota.raw" type="number" name="fs-config-quota-num" :id="getIdKey('fs-config-quota-num')" min="0" max="1000" class="text-default bg-default mt-1 w-fit block py-1.5 px-1.5 ml-1 text-default placeholder:text-muted input-textlike sm:text-sm sm:leading-6" />
+                    <select v-model="fileSystemConfig.properties.quota.unit" :id="getIdKey('fs-config-quota-size')" name="fs-config-quota-size" class="block sm:col-span-1 bg-default py-1.5 pl-3 pr-10 text-default input-textlike sm:text-sm sm:leading-6">
+                        <option value="kib">KiB</option>
+                        <option value="mib">MiB</option>
+                        <option value="gib">GiB</option>
+                        <option value="tib">TiB</option>
+                    </select>
+                </div>
+                <div class="flex flex-row justify-between">
+                    <div v-if="fileSystemConfig.properties.quota.raw !== null" class="mt-2 justify-self-start">
+                        <p class="text-muted">Used Space: {{ convertBytesToSize(fileSystemConfig.properties.used!) }}</p>
+                    </div>
+                    <div v-if="fileSystemConfig.properties.quota.raw === null || !fileSystemConfig.properties.quota.raw" class="mt-2 justify-self-end">
+                        <p class="text-muted">There is no quota currently set.</p>
+                    </div>
+                </div>
+
+            </div>
+
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-recordsize')" class="block text-sm font-medium leading-6 text-default">Record Size</label>
+                <select :id="getIdKey('fs-config-recordsize')" v-model="fileSystemConfig.properties.recordSize" name="fs-config-recordsize" class="mt-1 block w-full input-textlike bg-default">
+                    <option value="512">512 B</option>
+                    <option value="4K">4 KiB</option>
+                    <option value="8K">8 KiB</option>
+                    <option value="16K">16 KiB</option>
+                    <option value="32K">32 KiB</option>
+                    <option value="64K">64 KiB</option>
+                    <option value="128K">128 KiB</option>
+                    <option value="256K">256 KiB</option>
+                    <option value="512K">512 KiB</option>
+                    <option value="1M">1 MiB</option>
+                </select>
+            </div>
+
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-refreservation')" class="mb-1 block text-sm font-medium leading-6 text-default">Refreservation</label>
+                <div class="flex flex-row">
+                    <input v-model="fileSystemConfig.properties.refreservation!.raw" :id="getIdKey('fs-config-refreservation-amount')" name="fs-config-refreservation-slider" type="range" min="0" max="1000" step="1" class="text-default mt-5 w-3/4 h-2 bg-accent rounded-lg appearance-none cursor-pointer " />
+                    <input v-model="fileSystemConfig.properties.refreservation!.raw" type="number" name="fs-config-refreservation-num" :id="getIdKey('fs-config-refreservation-num')" min="0" max="1000" class="text-default bg-default mt-1 w-fit block py-1.5 px-1.5 ml-1 text-default placeholder:text-muted input-textlike sm:text-sm sm:leading-6" />
+                    <select v-model="fileSystemConfig.properties.refreservation!.unit" :id="getIdKey('fs-config-refreservation-size')" name="fs-config-refreservation-size" class="block sm:col-span-1 bg-default py-1.5 pl-3 pr-10 text-default input-textlike sm:text-sm sm:leading-6">
+                        <option value="kib">KiB</option>
+                        <option value="mib">MiB</option>
+                        <option value="gib">GiB</option>
+                        <option value="tib">TiB</option>
+                    </select>
+                </div>
+                <div class="flex flex-row justify-between">
+
+                    <div v-if="fileSystemConfig.properties.refreservation!.raw !== null" class="mt-2 justify-self-start">
+                        <p class="text-muted">Available Space: {{ convertBytesToSize(fileSystemConfig.properties.available) }}</p>
+                    </div>
+                    <div v-if="fileSystemConfig.properties.refreservation!.raw === null || !fileSystemConfig.properties.refreservation!.raw" class="mt-2 justify-self-end">
+                        <p class="text-muted">There is no refreservation currently set.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-acl-inherit')" class="bg-default block text-base leading-6 text-default">ACL Inheritance</label>
+                <select :id="getIdKey('fs-config-acl-inherit')" v-model="fileSystemConfig.properties.aclInheritance" name="fs-config-acl-inherit" class="mt-1 block w-full input-textlike bg-default">
+                    <option value="discard">Discard</option>
+                    <option value="noallow">No Allow</option>
+                    <option value="restricted">Restricted</option>
+                    <option value="passthrough">Passthrough</option>
+                    <option value="passthrough-x">Passthrough-X</option>
+                </select>
+            </div>
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-acl-type')" class="bg-default block text-base leading-6 text-default">ACL Type</label>
+                <select :id="getIdKey('fs-config-acl-type')" v-model="fileSystemConfig.properties.aclType" name="fs-config-acl-type" class="mt-1 block w-full input-textlike bg-default">
+                    <option value="off">Off/No ACL</option>
+                    <option value="posix">POSIX ACL</option>
+                </select>
+            </div>
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-access-time')" class="bg-default block text-base leading-6 text-default">Access Time</label>
+                <select :id="getIdKey('fs-config-access-time')" v-model="fileSystemConfig.properties.accessTime" name="fs-config-access-time" class="mt-1 block w-full input-textlike bg-default">
+                    <option value="on">On</option>
+                    <option value="off">Off</option>
+                </select>
+            </div>
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-dedup')" class="bg-default block text-base leading-6 text-default">Deduplication</label>
+                <select :id="getIdKey('fs-config-dedup')" v-model="fileSystemConfig.properties.deduplication" name="fs-config-dedup" class="mt-1 block w-full input-textlike bg-default">
+                    <option value="on">On</option>
+                    <option value="off">Off</option>
+                    <option value="edonr,verify">Edon-R + Verify</option>
+                    <option value="sha256">SHA-256</option>
+                    <option value="sha256,verify">SHA-256 + Verify</option>
+                    <option value="sha512">SHA-512</option>
+                    <option value="sha512,verify">SHA-512 + Verify</option>
+                    <option value="skein">Skein</option>
+                    <option value="skein,verify">Skein + Verify</option>
+                    <option value="verify">Verify</option>
+                </select>
+            </div>
+
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-compression')" class="bg-default block text-base leading-6 text-default">Compression</label>
+                <select :id="getIdKey('fs-config-compression')" v-model="fileSystemConfig.properties.compression" name="fs-config-compression" class="mt-1 block w-full input-textlike bg-default">
+                    <option value="on">On</option>
+                    <option value="off">Off</option>
+                    <option value="gzip">GZIP</option>
+                    <option value="lz4">LZ4</option>
+                    <option value="lzjb">LZJB</option>
+                    <option value="zle">ZLE</option>
+                </select>
+            </div>
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-checksum')" class="bg-default block text-base leading-6 text-default">Checksum</label>
+                <select :id="getIdKey('fs-config-checksum')" v-model="fileSystemConfig.properties.checksum" name="fs-config-checksum" class="mt-1 block w-full input-textlike bg-default">
+                    <option value="on">On</option>
+                    <option value="off">Off</option>
+                    <option value="edonr">Edon-R</option>
+                    <option value="fletcher2">Fletcher2</option>
+                    <option value="fletcher4">Fletcher4</option>
+                    <option value="noparity">No Parity</option>
+                    <option value="sha256">SHA-256</option>
+                    <option value="sha512">SHA-512</option>
+                    <option value="skein">Skein</option>
+                </select>
+            </div>
+
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-dnode-size')" class="bg-default block text-base leading-6 text-default">DNode Size</label>
+                <select :id="getIdKey('fs-config-dnode-size')" v-model="fileSystemConfig.properties.dNodeSize" name="fs-config-dnode-size" class="mt-1 block w-full input-textlike bg-default">
+                    <option value="1k">1 KiB</option>
+                    <option value="2k">2 KiB</option>
+                    <option value="4k">4 KiB</option>
+                    <option value="8k">8 KiB</option>
+                    <option value="16k">16 KiB</option>
+                    <option value="auto">Auto</option>
+                    <option value="legacy">Legacy</option>
+                </select>
+            </div>
+
+            <div class="mt-2">
+                <label :for="getIdKey('fs-config-xattr')" class="bg-default block text-base leading-6 text-default">Extended Attributes</label>
+                <select :id="getIdKey('fs-config-xattr')" v-model="fileSystemConfig.properties.extendedAttributes" name="fs-config-xattr" class="mt-1 block w-full input-textlike bg-default">
+                    <option value="on">On</option>
+                    <option value="off">Off</option>
+                    <option value="sa">System Attribute</option>
+                </select>
+            </div>
+
+            <div v-if="props.filesystem.encrypted" class="mt-2">
+                <label :for="getIdKey('fs-config-encryption')" name="fs-config-encryption" class="bg-default block text-base leading-6 text-default">Encryption</label>
+                <p class="mt-1 block w-full bg-default">{{ props.filesystem.properties.encryption.toUpperCase() }}</p>
+            </div>
+        </div>
+
+        <template #footer>
             <div class="w-full grid grid-rows-2">
                 <div class="w-full row-start-1">
                     <div class="mt-2">
@@ -230,15 +214,15 @@
                 </div>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 </template>
 
 <script setup lang="ts">
 import { ref, Ref, inject } from 'vue';
 import { onOffToBool, isBoolOnOff, upperCaseWord, convertBytesToSize, convertSizeToBytes, getSizeNumberFromString, getSizeUnitFromString, getQuotaRefreservUnit } from '../../composables/helpers';
 import { configureDataset } from '../../composables/datasets';
-import { Switch } from '@headlessui/vue';
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
+import PfSwitch from '../pf/PfSwitch.vue';
 import { loadDatasets } from '../../composables/loadData';
 import { ZFSFileSystemInfo, ZPool } from '@45drives/houston-common-lib';
 import { pushNotification, Notification } from '@45drives/houston-common-ui';

--- a/zfs/src/components/file-systems/FileSystemList.vue
+++ b/zfs/src/components/file-systems/FileSystemList.vue
@@ -151,6 +151,7 @@
 									<td class="pf-v5-c-table__td text-white" role="cell">N/A</td>
 									<td class="pf-v5-c-table__td text-white" role="cell">N/A</td>
 									<td class="pf-v5-c-table__td text-white" role="cell">N/A</td>
+									<td class="pf-v5-c-table__td text-white" role="cell">N/A</td>
 									<td class="pf-v5-c-table__td text-white text-center" role="cell">
 										<LockOpenIcon v-if="dataset.properties.encryption.value !== 'off' && dataset.properties.keystatus.value == 'available'"
 											class="w-5 inline-block" title="Encrypted &amp; Unlocked" aria-hidden="true" />

--- a/zfs/src/components/file-systems/FileSystemList.vue
+++ b/zfs/src/components/file-systems/FileSystemList.vue
@@ -18,311 +18,152 @@
 			<div class="inline-block min-w-full min-h-full shadow align-middle rounded-md border border-default">
 				<div class="overflow-visible ring-1 ring-black ring-opacity-5 rounded-md">
 
-					<table class="min-w-full divide-y divide-default rounded-md">
-						<thead class="rounded-md">
-							<tr
-								class="bg-well rounded-t-md grid grid-cols-[2rem_4fr_repeat(9,_minmax(0,_1fr))_2.25rem]">
-								<th class="relative py-2 rounded-tl-md col-span-1">
-									<span class="sr-only"></span>
+					<table class="pf-v5-c-table pf-m-compact min-w-full" role="grid">
+						<thead>
+							<tr role="row">
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col" style="width: 2rem;">
+									<span class="sr-only">Expand</span>
 								</th>
-								<th class="py-2 font-semibold text-center text-default col-span-1" :class="truncateText"
-									title="Dataset">Dataset</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Available">Available</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Used">Used</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Used">Used By Snapshots</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Refreservation">Refres.</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Compression">Compression</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Deduplication">Dedup.</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Encrypted">Encrypted</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Mounted">Mounted</th>
-								<th class="py-2 font-semibold text-default col-span-1" :class="truncateText"
-									title="Read Only">Read Only</th>
-								<th class="relative py-2 sm:pr-6 lg:pr-8 rounded-tr-md col-span-1">
-									<span class="sr-only"></span>
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col">Dataset</th>
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col">Available</th>
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col">Used</th>
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col">Used By Snapshots</th>
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col">Refres.</th>
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col">Compression</th>
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col">Dedup.</th>
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col">Encrypted</th>
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col">Mounted</th>
+								<th class="pf-v5-c-table__th" role="columnheader" scope="col">Read Only</th>
+								<th class="pf-v5-c-table__th pf-v5-c-table__action" role="columnheader" scope="col">
+									<span class="sr-only">Actions</span>
 								</th>
-
 							</tr>
 						</thead>
 
-						<tbody class="">
-							<tr class="">
-								<div v-if="allDatasets.length > 0 && allDatasetsLoaded == true">
-									<div v-for="dataset, datasetIdx in allDatasets" :key="dataset.name">
+						<tbody v-if="allDatasets.length > 0 && allDatasetsLoaded == true" role="rowgroup">
+							<template v-for="(dataset, datasetIdx) in allDatasets" :key="dataset.name">
 
-										<div v-if="dataset.type == 'FILESYSTEM'" class="border border-default">
-											<Disclosure v-slot="{ open }">
-												<DisclosureButton
-													class="bg-default grid grid-cols-[2rem_4fr_repeat(9,_minmax(0,_1fr))_2.25rem] w-full items-center">
-													<div class="py-1 mt-1 col-span-1 pl-2 justify-self-start"
-														:title="dataset.name">
-														<ChevronUpIcon
-															class="h-10 w-10 text-default transition-all duration-200 transform"
-															:class="{ 'rotate-90': !open, 'rotate-180': open, }" />
-													</div>
-													<div class="py-1 mt-1 col-span-1 text-left min-w-0"
-														:class="[truncateText, `ml-${getNestingLevel(dataset)}`]"
-														:title="dataset.name">{{ dataset.name }}</div>
-													<div class="py-1 mt-1 px-2 text-center font-medium col-span-1 min-w-0"
-														:class="truncateText"
-														:title="convertBytesToSize(dataset.properties.available) ? convertBytesToSize(dataset.properties.available) : 'N/A'">
-														{{ convertBytesToSize(dataset.properties.available) ?
-														convertBytesToSize(dataset.properties.available) : 'N/A' }}
-													</div>
-													<div class="py-1 mt-1 px-2 text-center font-medium col-span-1 min-w-0"
-														:class="truncateText" :title="dataset.properties.usedByDataset">
-														{{
-														dataset.properties.usedByDataset }}</div>
-													<div class="py-1 mt-1 px-2 text-center font-medium col-span-1 min-w-0"
-														:class="truncateText"
-														:title="dataset.properties.usedBySnapshots">{{
-														dataset.properties.usedBySnapshots }}</div>
-													<div class="py-1 mt-1 px-2 text-center font-medium col-span-1 min-w-0"
-														:class="truncateText"
-														:title="dataset.properties.usedbyRefreservation ? dataset.properties.usedbyRefreservation : 'N/A'">
-														{{ dataset.properties.usedbyRefreservation ?
-														dataset.properties.usedbyRefreservation : 'N/A' }}</div>
-													<div v-if="dataset.properties.compression == 'off' || dataset.properties.compression == 'on'"
-														class="py-1 mt-1 col-span-1" :class="truncateText"
-														:title="upperCaseWord(dataset.properties.compression) ? upperCaseWord(dataset.properties.compression) : 'N/A'">
-														{{ upperCaseWord(dataset.properties.compression) ?
-														upperCaseWord(dataset.properties.compression) : 'N/A' }}</div>
-													<div v-else class="py-1 mt-1 col-span-1" :class="truncateText"
-														:title="upperCaseWord(dataset.properties.compression).toUpperCase() ? upperCaseWord(dataset.properties.compression).toUpperCase() : 'N/A'">
-														{{ dataset.properties.compression.toUpperCase() ?
-														dataset.properties.compression.toUpperCase() : 'N/A' }}</div>
-													<div class="py-1 mt-1 px-2 text-center font-medium col-span-1 min-w-0"
-														:class="truncateText"
-														:title="getValue('dedup', dataset.properties.deduplication) ? getValue('dedup', dataset.properties.deduplication) : 'N/A'">
-														{{ getValue('dedup', dataset.properties.deduplication) ?
-														getValue('dedup', dataset.properties.deduplication) : 'N/A' }}
-													</div>
+								<!-- FILESYSTEM rows -->
+								<template v-if="dataset.type == 'FILESYSTEM'">
+									<tr class="pf-v5-c-table__tr pf-v5-c-table__expandable-row-control bg-default border border-default cursor-pointer"
+										role="row"
+										@click="toggleExpanded(dataset.name)">
+										<td class="pf-v5-c-table__td pf-v5-c-table__toggle" role="cell">
+											<button class="pf-v5-c-button pf-m-plain" type="button"
+												:aria-expanded="isExpanded.has(dataset.name)"
+												@click.stop="toggleExpanded(dataset.name)">
+												<ChevronUpIcon
+													class="h-5 w-5 text-default transition-all duration-200 transform"
+													:class="{ 'rotate-90': !isExpanded.has(dataset.name), 'rotate-180': isExpanded.has(dataset.name) }" />
+											</button>
+										</td>
+										<td class="pf-v5-c-table__td" role="cell"
+											:class="truncateText"
+											:style="{ paddingLeft: `${getNestingLevel(dataset) * 0.25}rem` }"
+											:title="dataset.name">{{ dataset.name }}</td>
+										<td class="pf-v5-c-table__td" role="cell"
+											:class="truncateText"
+											:title="convertBytesToSize(dataset.properties.available) ? convertBytesToSize(dataset.properties.available) : 'N/A'">
+											{{ convertBytesToSize(dataset.properties.available) ?
+											convertBytesToSize(dataset.properties.available) : 'N/A' }}
+										</td>
+										<td class="pf-v5-c-table__td" role="cell"
+											:class="truncateText" :title="dataset.properties.usedByDataset">
+											{{ dataset.properties.usedByDataset }}</td>
+										<td class="pf-v5-c-table__td" role="cell"
+											:class="truncateText"
+											:title="dataset.properties.usedBySnapshots">{{
+											dataset.properties.usedBySnapshots }}</td>
+										<td class="pf-v5-c-table__td" role="cell"
+											:class="truncateText"
+											:title="dataset.properties.usedbyRefreservation ? dataset.properties.usedbyRefreservation : 'N/A'">
+											{{ dataset.properties.usedbyRefreservation ?
+											dataset.properties.usedbyRefreservation : 'N/A' }}</td>
+										<td class="pf-v5-c-table__td" role="cell"
+											:class="truncateText"
+											:title="getCompressionDisplay(dataset)">
+											{{ getCompressionDisplay(dataset) }}
+										</td>
+										<td class="pf-v5-c-table__td" role="cell"
+											:class="truncateText"
+											:title="getValue('dedup', dataset.properties.deduplication) ? getValue('dedup', dataset.properties.deduplication) : 'N/A'">
+											{{ getValue('dedup', dataset.properties.deduplication) ?
+											getValue('dedup', dataset.properties.deduplication) : 'N/A' }}
+										</td>
 
-													<div v-if="dataset.encrypted && dataset.key_loaded"
-														class="py-1 mt-1 col-span-1 justify-self-center"
-														title="Encrypted & Unlocked">
-														<LockOpenIcon class="w-5 mt-0.5" aria-hidden="true" />
-													</div>
-													<div v-if="dataset.encrypted && !dataset.key_loaded"
-														class="py-1 mt-1 col-span-1 justify-self-center"
-														title="Encrypted & Locked">
-														<LockClosedIcon class="w-5 mt-0.5" aria-hidden="true" />
-													</div>
-													<div v-if="!dataset.encrypted"
-														class="py-1 mt-1 col-span-1 justify-self-center"
-														title="Not Encrypted">
-														<NoSymbolIcon class="w-5 mt-0.5" aria-hidden="true" />
-													</div>
+										<td class="pf-v5-c-table__td text-center" role="cell">
+											<LockOpenIcon v-if="dataset.encrypted && dataset.key_loaded"
+												class="w-5 inline-block" title="Encrypted &amp; Unlocked" aria-hidden="true" />
+											<LockClosedIcon v-else-if="dataset.encrypted && !dataset.key_loaded"
+												class="w-5 inline-block" title="Encrypted &amp; Locked" aria-hidden="true" />
+											<NoSymbolIcon v-else
+												class="w-5 inline-block" title="Not Encrypted" aria-hidden="true" />
+										</td>
 
-													<div v-if="yesNoToBool(dataset.properties.mounted)"
-														class="py-1 mt-1 col-span-1 justify-self-center"
-														title="Mounted">
-														<CheckIcon class="w-5 mt-0.5" aria-hidden="true" />
-													</div>
-													<div v-if="!yesNoToBool(dataset.properties.mounted)"
-														class="py-1 mt-1 col-span-1 justify-self-center"
-														title="Not Mounted">
-														<NoSymbolIcon class="w-5 mt-0.5" aria-hidden="true" />
-													</div>
+										<td class="pf-v5-c-table__td text-center" role="cell">
+											<CheckIcon v-if="yesNoToBool(dataset.properties.mounted)"
+												class="w-5 inline-block" title="Mounted" aria-hidden="true" />
+											<NoSymbolIcon v-else
+												class="w-5 inline-block" title="Not Mounted" aria-hidden="true" />
+										</td>
 
-													<div v-if="dataset.properties.isReadOnly!"
-														class="py-1 mt-1 col-span-1 justify-self-center"
-														title="Read Only ON">
-														<CheckIcon class="w-5 mt-0.5" aria-hidden="true" />
-													</div>
-													<div v-if="!dataset.properties.isReadOnly!"
-														class="py-1 mt-1 col-span-1 justify-self-center"
-														title="Read Only OFF">
-														<NoSymbolIcon class="w-5 mt-0.5" aria-hidden="true" />
-													</div>
+										<td class="pf-v5-c-table__td text-center" role="cell">
+											<CheckIcon v-if="dataset.properties.isReadOnly!"
+												class="w-5 inline-block" title="Read Only ON" aria-hidden="true" />
+											<NoSymbolIcon v-else
+												class="w-5 inline-block" title="Read Only OFF" aria-hidden="true" />
+										</td>
 
-													<div class="py-1 mt-1 pr-2 col-span-1 justify-self-end">
-														<Menu as="div" class="relative inline-block text-right -mt-1">
-															<div>
-																<MenuButton @click.stop :disabled="!canDestructive"
-																	:aria-disabled="!canDestructive"
-																	:title="!canDestructive ? 'Requires administrative privileges' : ''"
-																	:class="[
-																		'flex items-center rounded-full p-2 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 focus:ring-offset-gray-100',
-																		canDestructive ? 'bg-default hover:text-white cursor-pointer'
-																			: 'bg-default/60 text-muted cursor-not-allowed'
-																	]">
-																	<span class="sr-only">Open options</span>
-																	<EllipsisVerticalIcon class="w-5"
-																		aria-hidden="true" />
-																</MenuButton>
-															</div>
+										<td class="pf-v5-c-table__td pf-v5-c-table__action" role="cell" @click.stop>
+											<PfDropdownMenu
+												:items="getFileSystemActions(allDatasets[datasetIdx], datasetIdx)"
+												:kebab="true"
+											/>
+										</td>
+									</tr>
 
-															<transition
-																enter-active-class="transition ease-out duration-100"
-																enter-from-class="transform opacity-0 scale-95"
-																enter-to-class="transform opacity-100 scale-100"
-																leave-active-class="transition ease-in duration-75"
-																leave-from-class="transform opacity-100 scale-100"
-																leave-to-class="transform opacity-0 scale-95">
-																<MenuItems @click.stop
-																	class="absolute right-0 z-10 w-56 origin-top-right rounded-md bg-accent shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-																	<div class="py-1">
-																		<MenuItem as="div" v-slot="{ active }">
-																		<a href="#"
-																			@click="loadFileSystemConfig(allDatasets[datasetIdx])"
-																			:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Configure
-																			File System</a>
-																		</MenuItem>
-																		<MenuItem as="div"
-																			v-if="!findPoolDataset(allDatasets[datasetIdx])"
-																			v-slot="{ active }">
-																		<a href="#"
-																			@click="renameThisDataset(allDatasets[datasetIdx])"
-																			:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Rename
-																			File System</a>
-																		</MenuItem>
-																		<MenuItem as="div"
-																			v-if="allDatasets[datasetIdx].properties.mounted == 'yes'"
-																			v-slot="{ active }">
-																		<a href="#"
-																			@click="unmountThisFileSystem(allDatasets[datasetIdx])"
-																			:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Unmount
-																			File System</a>
-																		</MenuItem>
-																		<MenuItem as="div"
-																			v-if="allDatasets[datasetIdx].properties.mounted == 'no' && !allDatasets[datasetIdx].encrypted"
-																			v-slot="{ active }">
-																		<a href="#"
-																			@click="mountThisFileSystem(allDatasets[datasetIdx])"
-																			:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Mount
-																			File System</a>
-																		</MenuItem>
-																		<MenuItem as="div"
-																			v-if="allDatasets[datasetIdx].properties.mounted == 'no' && allDatasets[datasetIdx].encrypted && allDatasets[datasetIdx].key_loaded"
-																			v-slot="{ active }">
-																		<a href="#"
-																			@click="mountThisFileSystem(allDatasets[datasetIdx])"
-																			:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Mount
-																			File System</a>
-																		</MenuItem>
-																		<MenuItem as="div"
-																			v-if="allDatasets[datasetIdx].properties.mounted == 'no' && allDatasets[datasetIdx].encrypted && !allDatasets[datasetIdx].key_loaded"
-																			v-slot="{ active }">
-																		<a href="#"
-																			@click="handleFileSystemEncryption(allDatasets[datasetIdx], 'unlock')"
-																			:class="[active ? 'bg-green-600 text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Unlock
-																			File System</a>
-																		</MenuItem>
-																		<MenuItem as="div"
-																			v-if="allDatasets[datasetIdx].properties.mounted == 'no' && allDatasets[datasetIdx].encrypted && allDatasets[datasetIdx].key_loaded"
-																			v-slot="{ active }">
-																		<a href="#"
-																			@click="handleFileSystemEncryption(allDatasets[datasetIdx], 'lock')"
-																			:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Lock
-																			File System</a>
-																		</MenuItem>
-																		<MenuItem as="div"
-																			v-if="allDatasets[datasetIdx].encrypted && allDatasets[datasetIdx].key_loaded"
-																			v-slot="{ active }">
-																		<a href="#"
-																			@click="changeThisPassphrase(allDatasets[datasetIdx])"
-																			:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Change
-																			Passphrase</a>
-																		</MenuItem>
-																		<MenuItem as="div" v-slot="{ active }">
-																		<a href="#"
-																			@click="createSnapshotBtn(allDatasets[datasetIdx])"
-																			:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Create
-																			Snapshot</a>
-																		</MenuItem>
-																		<MenuItem as="div"
-																			v-if="!findPoolDataset(allDatasets[datasetIdx])"
-																			v-slot="{ active }">
-																		<a href="#"
-																			@click="deleteFileSystem(allDatasets[datasetIdx])"
-																			:class="[active ? 'bg-danger text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Destroy
-																			File System</a>
-																		</MenuItem>
-																		<MenuItem as="div"
-																			v-if="!bulkSnapDestroyMode.get(dataset.name)"
-																			v-slot="{ active }">
-																		<a href="#"
-																			@click="enterBulkSnapDestroyMode(allDatasets[datasetIdx])"
-																			:class="[active ? 'bg-danger text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Bulk
-																			Destroy Snapshot Mode</a>
-																		</MenuItem>
-																		<MenuItem as="div"
-																			v-if="bulkSnapDestroyMode.get(dataset.name)"
-																			v-slot="{ active }">
-																		<a href="#"
-																			@click="exitBulkSnapDestroyMode(allDatasets[datasetIdx])"
-																			:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Leave
-																			Bulk Destroy Mode</a>
-																		</MenuItem>
-																	</div>
-																</MenuItems>
-															</transition>
-														</Menu>
-													</div>
-												</DisclosureButton>
+									<!-- Expandable row for snapshots -->
+									<tr v-if="isExpanded.has(dataset.name)"
+										class="pf-v5-c-table__expandable-row pf-m-expanded" role="row">
+										<td :colspan="12" class="pf-v5-c-table__td p-0" role="cell">
+											<SnapshotsList :filesystem="allDatasets[datasetIdx]"
+												:item="'filesystem'"
+												:bulkSnapDestroyMode="bulkSnapDestroyMode.get(allDatasets[datasetIdx].name)" />
+										</td>
+									</tr>
+								</template>
 
-												<DisclosurePanel>
-													<SnapshotsList :filesystem="allDatasets[datasetIdx]"
-														:item="'filesystem'"
-														:bulkSnapDestroyMode="bulkSnapDestroyMode.get(allDatasets[datasetIdx].name)" />
-												</DisclosurePanel>
-
-											</Disclosure>
-										</div>
-										<div v-if="dataset.type == 'SNAPSHOT'" class="border border-default">
-											<div
-												class="bg-primary grid grid-cols-[2rem_3fr_repeat(9,_minmax(0,_1fr))_2rem] w-full justify-center text-center">
-												<div class="py-1 mt-1 mr-2 col-span-1 ml-4 justify-self-start"
-													:title="dataset.name">
-													<CameraIcon class="-mt-1 mx-2 h-8 w-8 text-muted" />
-												</div>
-												<div class="py-1 mt-1 col-span-1 text-left text-white"
-													:class="[truncateText, `ml-${getNestingLevel(dataset)}`]"
-													:title="dataset.name">{{ dataset.name }}</div>
-												<div class="py-1 mt-1 col-span-1 text-white">N/A</div>
-												<div class="py-1 mt-1 col-span-1 text-white" :class="truncateText"
-													:title="convertBytesToSize(dataset.properties.used.parsed)">{{
-													convertBytesToSize(dataset.properties.used.parsed) }}</div>
-												<div class="py-1 mt-1 col-span-1 text-white">N/A</div>
-												<div class="py-1 mt-1 col-span-1 text-white">N/A</div>
-												<div class="py-1 mt-1 col-span-1 text-white">N/A</div>
-												<div v-if="dataset.properties.encryption.value !== 'off' && dataset.properties.keystatus.value == 'available'"
-													class="py-1 mt-1 col-span-1 text-white justify-self-center items-center text-center"
-													title="Encrypted & Unlocked">
-													<LockOpenIcon class="w-5 mt-0.5" aria-hidden="true" />
-												</div>
-												<div v-if="dataset.properties.encryption.value !== 'off' && dataset.properties.keystatus.value == 'unavailable'"
-													class="py-1 mt-1 col-span-1 text-white justify-self-center items-center text-center"
-													title="Encrypted & Locked">
-													<LockClosedIcon class="w-5 mt-0.5" aria-hidden="true" />
-												</div>
-												<div v-if="dataset.properties.encryption.value === 'off' && dataset.properties.keystatus.value == ''"
-													class="py-1 mt-1 col-span-1 text-white justify-self-center items-center text-center"
-													title="Not Encrypted">
-													<NoSymbolIcon class="w-5 mt-0.5" aria-hidden="true" />
-												</div>
-												<div
-													class="py-1 mt-1 col-span-1 text-white justify-self-center items-center text-center">
-													N/A</div>
-												<div
-													class="py-1 mt-1 col-span-1 text-white justify-self-center items-center text-center">
-													N/A</div>
-												<div
-													class="relative py-1 mt-1 p-3 text-right font-medium sm:pr-6 lg:pr-8">
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-							</tr>
+								<!-- SNAPSHOT rows -->
+								<tr v-if="dataset.type == 'SNAPSHOT'"
+									class="pf-v5-c-table__tr bg-primary border border-default" role="row">
+									<td class="pf-v5-c-table__td" role="cell">
+										<CameraIcon class="h-6 w-6 text-muted" />
+									</td>
+									<td class="pf-v5-c-table__td text-white" role="cell"
+										:class="truncateText"
+										:style="{ paddingLeft: `${getNestingLevel(dataset) * 0.25}rem` }"
+										:title="dataset.name">{{ dataset.name }}</td>
+									<td class="pf-v5-c-table__td text-white" role="cell">N/A</td>
+									<td class="pf-v5-c-table__td text-white" role="cell"
+										:class="truncateText"
+										:title="convertBytesToSize(dataset.properties.used.parsed)">{{
+										convertBytesToSize(dataset.properties.used.parsed) }}</td>
+									<td class="pf-v5-c-table__td text-white" role="cell">N/A</td>
+									<td class="pf-v5-c-table__td text-white" role="cell">N/A</td>
+									<td class="pf-v5-c-table__td text-white" role="cell">N/A</td>
+									<td class="pf-v5-c-table__td text-white text-center" role="cell">
+										<LockOpenIcon v-if="dataset.properties.encryption.value !== 'off' && dataset.properties.keystatus.value == 'available'"
+											class="w-5 inline-block" title="Encrypted &amp; Unlocked" aria-hidden="true" />
+										<LockClosedIcon v-else-if="dataset.properties.encryption.value !== 'off' && dataset.properties.keystatus.value == 'unavailable'"
+											class="w-5 inline-block" title="Encrypted &amp; Locked" aria-hidden="true" />
+										<NoSymbolIcon v-else
+											class="w-5 inline-block" title="Not Encrypted" aria-hidden="true" />
+									</td>
+									<td class="pf-v5-c-table__td text-white text-center" role="cell">N/A</td>
+									<td class="pf-v5-c-table__td text-white text-center" role="cell">N/A</td>
+									<td class="pf-v5-c-table__td" role="cell"></td>
+								</tr>
+							</template>
 						</tbody>
 					</table>
 
@@ -418,14 +259,15 @@
 
 <script setup lang="ts">
 import { ref, inject, Ref, provide, watch, onMounted, computed, reactive } from "vue";
-import { EllipsisVerticalIcon, ArrowPathIcon, ChevronUpIcon, LockClosedIcon, LockOpenIcon, NoSymbolIcon, CheckIcon, } from '@heroicons/vue/24/outline';
+import { ArrowPathIcon, ChevronUpIcon, LockClosedIcon, LockOpenIcon, NoSymbolIcon, CheckIcon, } from '@heroicons/vue/24/outline';
 import { CameraIcon } from '@heroicons/vue/24/solid'
-import { Menu, MenuButton, MenuItem, MenuItems, Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue';
 import { loadDatasets, loadSnapshots } from "../../composables/loadData";
 import { getValue, convertBytesToSize, upperCaseWord, yesNoToBool } from '../../composables/helpers';
 import { destroyDataset, unmountFileSystem, mountFileSystem, lockFileSystem } from "../../composables/datasets";
 import LoadingSpinner from "../common/LoadingSpinner.vue";
 import SnapshotsList from "../snapshots/SnapshotsList.vue";
+import PfDropdownMenu from "../pf/PfDropdownMenu.vue";
+import type { DropdownMenuItem } from "../pf/PfDropdownMenu.vue";
 import { ZPool, ZFSFileSystemInfo } from "@45drives/houston-common-lib";
 import { pushNotification, Notification } from '@45drives/houston-common-ui';
 import { ConfirmationCallback, Snapshot } from "../../types";
@@ -433,7 +275,138 @@ import { getSnapshotsOfDataset } from "../../composables/snapshots";
 
 const truncateText = inject<Ref<string>>('style-truncate-text')!;
 const canDestructive = inject<Ref<boolean>>('can-destructive')!;
-	
+
+///////////////// Expandable Rows //////////////////
+/////////////////////////////////////////////////////
+const isExpanded = reactive(new Set<string>());
+
+function toggleExpanded(name: string) {
+	if (isExpanded.has(name)) {
+		isExpanded.delete(name);
+	} else {
+		isExpanded.add(name);
+	}
+}
+
+function getCompressionDisplay(dataset: any): string {
+	if (dataset.properties.compression === 'off' || dataset.properties.compression === 'on') {
+		return upperCaseWord(dataset.properties.compression) || 'N/A';
+	}
+	return dataset.properties.compression?.toUpperCase() || 'N/A';
+}
+
+///////////////// Dropdown Actions /////////////////
+/////////////////////////////////////////////////////
+function getFileSystemActions(dataset: any, datasetIdx: number): DropdownMenuItem[] {
+	const items: DropdownMenuItem[] = [];
+
+	items.push({
+		label: 'Configure File System',
+		action: () => loadFileSystemConfig(allDatasets.value[datasetIdx]),
+		disabled: !canDestructive.value,
+		tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+	});
+
+	if (!findPoolDataset(allDatasets.value[datasetIdx])) {
+		items.push({
+			label: 'Rename File System',
+			action: () => renameThisDataset(allDatasets.value[datasetIdx]),
+			disabled: !canDestructive.value,
+			tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+		});
+	}
+
+	if (allDatasets.value[datasetIdx].properties.mounted == 'yes') {
+		items.push({
+			label: 'Unmount File System',
+			action: () => unmountThisFileSystem(allDatasets.value[datasetIdx]),
+			disabled: !canDestructive.value,
+			tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+		});
+	}
+
+	if (allDatasets.value[datasetIdx].properties.mounted == 'no' && !allDatasets.value[datasetIdx].encrypted) {
+		items.push({
+			label: 'Mount File System',
+			action: () => mountThisFileSystem(allDatasets.value[datasetIdx]),
+			disabled: !canDestructive.value,
+			tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+		});
+	}
+
+	if (allDatasets.value[datasetIdx].properties.mounted == 'no' && allDatasets.value[datasetIdx].encrypted && allDatasets.value[datasetIdx].key_loaded) {
+		items.push({
+			label: 'Mount File System',
+			action: () => mountThisFileSystem(allDatasets.value[datasetIdx]),
+			disabled: !canDestructive.value,
+			tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+		});
+	}
+
+	if (allDatasets.value[datasetIdx].properties.mounted == 'no' && allDatasets.value[datasetIdx].encrypted && !allDatasets.value[datasetIdx].key_loaded) {
+		items.push({
+			label: 'Unlock File System',
+			action: () => handleFileSystemEncryption(allDatasets.value[datasetIdx], 'unlock'),
+			disabled: !canDestructive.value,
+			tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+		});
+	}
+
+	if (allDatasets.value[datasetIdx].properties.mounted == 'no' && allDatasets.value[datasetIdx].encrypted && allDatasets.value[datasetIdx].key_loaded) {
+		items.push({
+			label: 'Lock File System',
+			action: () => handleFileSystemEncryption(allDatasets.value[datasetIdx], 'lock'),
+			disabled: !canDestructive.value,
+			tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+		});
+	}
+
+	if (allDatasets.value[datasetIdx].encrypted && allDatasets.value[datasetIdx].key_loaded) {
+		items.push({
+			label: 'Change Passphrase',
+			action: () => changeThisPassphrase(allDatasets.value[datasetIdx]),
+			disabled: !canDestructive.value,
+			tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+		});
+	}
+
+	items.push({
+		label: 'Create Snapshot',
+		action: () => createSnapshotBtn(allDatasets.value[datasetIdx]),
+		disabled: !canDestructive.value,
+		tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+	});
+
+	if (!findPoolDataset(allDatasets.value[datasetIdx])) {
+		items.push({
+			label: 'Destroy File System',
+			action: () => deleteFileSystem(allDatasets.value[datasetIdx]),
+			disabled: !canDestructive.value,
+			tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+		});
+	}
+
+	if (!bulkSnapDestroyMode.get(dataset.name)) {
+		items.push({
+			label: 'Bulk Destroy Snapshot Mode',
+			action: () => enterBulkSnapDestroyMode(allDatasets.value[datasetIdx]),
+			disabled: !canDestructive.value,
+			tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+		});
+	}
+
+	if (bulkSnapDestroyMode.get(dataset.name)) {
+		items.push({
+			label: 'Leave Bulk Destroy Mode',
+			action: () => exitBulkSnapDestroyMode(allDatasets.value[datasetIdx]),
+			disabled: !canDestructive.value,
+			tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined,
+		});
+	}
+
+	return items;
+}
+
 ///////// Values for Confirmation Modals ////////////
 /////////////////////////////////////////////////////
 const operationRunning = ref(false);

--- a/zfs/src/components/file-systems/LockUnlockFileSystem.vue
+++ b/zfs/src/components/file-systems/LockUnlockFileSystem.vue
@@ -1,80 +1,56 @@
 <template>
-    <OldModal :isOpen="showFlag" @close="updateShowFlag" :marginTop="'mt-60'" :width="'w-96'" :minWidth="'min-w-min'" :closeOnBackgroundClick="false">
-        <template v-slot:title>
-            <legend class="flex justify-center">{{ upperCaseWord(props.mode) }} File System</legend>
-        </template>
-        <template v-slot:content>
-            <div class="grid grid-flow-row mt-3 text-center">
-                <div v-if="props.mode == 'unlock'" class="w-full grid grid-cols-3">
-                    <div class="col-span-3 flex flex-row">
-                        <label :for="getIdKey('filesystem-name')" :class="truncateText" :title="props.filesystem.name" class="mt-1 block text-sm font-medium leading-6 text-default">Name: <span :class="truncateText" :title="props.filesystem.name" class="font-normal">{{ props.filesystem.name }}</span></label>
+    <PfModal :isOpen="showFlag" @close="closeModal" :title="`${upperCaseWord(props.mode)} File System`">
+        <div class="grid grid-flow-row mt-3 text-center">
+            <div v-if="props.mode == 'unlock'" class="w-full grid grid-cols-3">
+                <div class="col-span-3 flex flex-row">
+                    <label :for="getIdKey('filesystem-name')" :class="truncateText" :title="props.filesystem.name" class="mt-1 block text-sm font-medium leading-6 text-default">Name: <span :class="truncateText" :title="props.filesystem.name" class="font-normal">{{ props.filesystem.name }}</span></label>
+                </div>
+                <div class="col-span-3 justify-between text-center items-center grid grid-cols-3">
+                    <div class="col-span-2 flex flex-row gap-1 text-center items-center">
+                        <label :for="getIdKey('passphrase')" class="mt-1 block text-sm font-medium leading-6 text-default">Passphrase</label>
+                        <input v-if="showPassword == false" :id="getIdKey('passphrase-hidden')" type="password" @keydown.enter="confirmBtn()" v-model="passphrase" name="passphrase" class="mt-1 block w-fit input-textlike bg-default" placeholder="Enter here" />
+                        <input v-if="showPassword == true" :id="getIdKey('passphrase-shown')" type="text" @keydown.enter="confirmBtn()" v-model="passphrase" name="passphrase" class="mt-1 block w-fit input-textlike bg-default" placeholder="Enter here" />
                     </div>
-                    <div class="col-span-3 justify-between text-center items-center grid grid-cols-3">
-                        <div class="col-span-2 flex flex-row gap-1 text-center items-center">
-                            <label :for="getIdKey('passphrase')" class="mt-1 block text-sm font-medium leading-6 text-default">Passphrase</label>
-                            <input v-if="showPassword == false" :id="getIdKey('passphrase-hidden')" type="password" @keydown.enter="confirmBtn()" v-model="passphrase" name="passphrase" class="mt-1 block w-fit input-textlike bg-default" placeholder="Enter here" />
-                            <input v-if="showPassword == true" :id="getIdKey('passphrase-shown')" type="text" @keydown.enter="confirmBtn()" v-model="passphrase" name="passphrase" class="mt-1 block w-fit input-textlike bg-default" placeholder="Enter here" />
-                        </div>
-                        <div class="col-span-1 button-group-row justify-end">
-                            <button v-if="showPassword == true" class="btn btn-secondary max-h-min" @click="showPassword = false">
-                                <EyeSlashIcon class="h-5" />
-                            </button>
-                            <button v-if="showPassword == false" class="btn btn-secondary max-h-min" @click="showPassword = true">
-                                <EyeIcon class="h-5" />
-                            </button>
-                        </div>
-                    </div>
-
-                    <div class="col-span-3 flex flex-row">
-                        <p class="text-danger mt-1">{{ passFeedback }}</p>
-                    </div>
-                    <div class="grid grid-rows-2 col-span-3">
-                        <div class="flex flex-row justify-between">
-                            <label :for="getIdKey('mount-switch')" class="mt-3 mr-2 block text-sm font-medium text-default whitespace-nowrap">Mount File System</label>
-                            <Switch v-model="mountFS" :id="getIdKey('mount-file-system')" :class="[mountFS ? 'bg-primary' : 'bg-accent', 'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                                <span class="sr-only">Use setting</span>
-                                <span :class="[mountFS ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                    <span :class="[mountFS ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                        <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                            <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                        </svg>
-                                    </span>
-                                    <span :class="[mountFS ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                        <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                            <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                        </svg>
-                                    </span>
-                                </span>
-                            </Switch>
-                        </div>
-                        <div class="flex flex-row justify-between">
-                            <label :for="getIdKey('force-mount-switch')" class="mt-3 mr-2 block text-sm font-medium text-default whitespace-nowrap">Forcefully Mount File System</label>
-                            <Switch v-model="forceMountFS" :id="getIdKey('force-mount-file-system')" :class="[forceMountFS ? 'bg-primary' : 'bg-accent', 'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                                <span class="sr-only">Use setting</span>
-                                <span :class="[forceMountFS ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                    <span :class="[forceMountFS ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                        <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                            <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                        </svg>
-                                    </span>
-                                    <span :class="[forceMountFS ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                        <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                            <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                        </svg>
-                                    </span>
-                                </span>
-                            </Switch>
-                        </div>
+                    <div class="col-span-1 button-group-row justify-end">
+                        <button v-if="showPassword == true" class="btn btn-secondary max-h-min" @click="showPassword = false">
+                            <EyeSlashIcon class="h-5" />
+                        </button>
+                        <button v-if="showPassword == false" class="btn btn-secondary max-h-min" @click="showPassword = true">
+                            <EyeIcon class="h-5" />
+                        </button>
                     </div>
                 </div>
-                <div v-if="props.mode == 'lock'" class="w-full grid grid-cols-2">
-                    <div class="col-span-2">
-                        <legend :class="truncateText" :title="props.filesystem.name">Lock filesystem {{ props.filesystem.name }}?</legend>
+
+                <div class="col-span-3 flex flex-row">
+                    <p class="text-danger mt-1">{{ passFeedback }}</p>
+                </div>
+                <div class="grid grid-rows-2 col-span-3">
+                    <div class="flex flex-row justify-between">
+                        <label :for="getIdKey('mount-switch')" class="mt-3 mr-2 block text-sm font-medium text-default whitespace-nowrap">Mount File System</label>
+                        <PfSwitch
+                            :modelValue="mountFS"
+                            @update:modelValue="mountFS = $event"
+                            :id="getIdKey('mount-file-system')"
+                        />
+                    </div>
+                    <div class="flex flex-row justify-between">
+                        <label :for="getIdKey('force-mount-switch')" class="mt-3 mr-2 block text-sm font-medium text-default whitespace-nowrap">Forcefully Mount File System</label>
+                        <PfSwitch
+                            :modelValue="forceMountFS"
+                            @update:modelValue="forceMountFS = $event"
+                            :id="getIdKey('force-mount-file-system')"
+                        />
                     </div>
                 </div>
             </div>
-        </template>
-        <template v-slot:footer>
+            <div v-if="props.mode == 'lock'" class="w-full grid grid-cols-2">
+                <div class="col-span-2">
+                    <legend :class="truncateText" :title="props.filesystem.name">Lock filesystem {{ props.filesystem.name }}?</legend>
+                </div>
+            </div>
+        </div>
+
+        <template #footer>
             <div class="w-full grid grid-rows-1">
                 <div class="button-group-row mt-2 justify-between">
                     <button @click="closeModal" :id="getIdKey('confirm-no')" name="button-no" class="mt-1 btn btn-secondary object-left justify-start h-fit">Cancel</button>
@@ -89,15 +65,15 @@
                 </div>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 </template>
 <script setup lang="ts">
 import { Ref, inject, ref } from 'vue';
-import { Switch } from '@headlessui/vue';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/vue/24/outline';
 import { upperCaseWord } from '../../composables/helpers';
 import { lockFileSystem, mountFileSystem, unlockFileSystem, isPassphraseValid } from "../../composables/datasets";
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
+import PfSwitch from '../pf/PfSwitch.vue';
 import { pushNotification, Notification } from '@45drives/houston-common-ui';
 import { ZFSFileSystemInfo } from '@45drives/houston-common-lib';
 
@@ -118,12 +94,6 @@ const showPassword = ref(false);
 const doingThing = inject<Ref<boolean>>('locking-or-unlocking')!;
 const showLockUnlockModal = inject<Ref<boolean>>('show-lock-unlock-modal')!;
 const confirmLockOrUnlock = inject<Ref<boolean>>('confirm-lock-or-unlock')!;
-
-const updateShowFlag = () => {
-    if (props.showFlag !== showFlag.value) {
-        showFlag.value = props.showFlag;
-    } 
-}
 
 const closeModal = () => {
     emit('close');
@@ -154,13 +124,13 @@ async function confirmBtn() {
         } catch (error) {
             console.error(error);
         }
-        
+
     } else if (props.mode == 'unlock') {
         passValid.value = await isPassphraseValid(props.filesystem.name, passphrase.value);
-   
+
         if (passValid.value) {
             doingThing.value = true;
-            
+
             try {
                 const unlockOutput: any =  await unlockFileSystem(props.filesystem, passphrase.value);
 
@@ -173,7 +143,7 @@ async function confirmBtn() {
                     if (mountFS.value) {
                         try {
                             const mountOutput: any = await mountFileSystem(props.filesystem, forceMountFS.value);
-                        
+
                             if (mountOutput == null || mountOutput.error) {
                                 const errorMessage = mountOutput?.error || 'Unknown error';
                                 pushNotification(new Notification('Mount Dataset Failed', `${props.filesystem.name} was not mounted: ${errorMessage}`, 'error', 5000));
@@ -194,11 +164,11 @@ async function confirmBtn() {
             } catch (error) {
                 console.error(error);
             }
-          
+
         } else {
             passFeedback.value = 'Passphrase is invalid.';
         }
-    } 
+    }
 }
 
 const getIdKey = (name: string) => `${name}`;

--- a/zfs/src/components/file-systems/RenameFileSystem.vue
+++ b/zfs/src/components/file-systems/RenameFileSystem.vue
@@ -1,71 +1,47 @@
 <template>
-    <OldModal :isOpen="showRenameModal" @close="showRenameModal = false" :marginTop="'mt-28'" :width="'w-4/12'" :minWidth="'min-w-4/12'" :closeOnBackgroundClick="false">
-        <template v-slot:title>
-            <legend class="flex justify-center">Rename File System</legend>
-        </template>
-        <template v-slot:content>
-            <div>
-                <div class="">
-                    <!-- Parent File System -->
-                    <div class="mt-2">
-                        <label :for="getIdKey('parent-filesystem')" class="block text-sm font-medium leading-6 text-default">Parent File System</label>
-                        <select v-model="parentFS" :id="getIdKey('parent-filesystem')" class="text-default bg-default mt-1 block w-full input-textlike sm:text-sm sm:leading-6" :class="truncateText">
-                            <option v-for="dataset, datasetIdx in datasetsInSamePool" :class="truncateText" :title="dataset.name" :key="datasetIdx">{{ dataset.name }}</option>
-                        </select>
-                    </div>
+    <PfModal :isOpen="showRenameModal" @close="showRenameModal = false" title="Rename File System">
+        <div>
+            <div class="">
+                <!-- Parent File System -->
+                <div class="mt-2">
+                    <label :for="getIdKey('parent-filesystem')" class="block text-sm font-medium leading-6 text-default">Parent File System</label>
+                    <select v-model="parentFS" :id="getIdKey('parent-filesystem')" class="text-default bg-default mt-1 block w-full input-textlike sm:text-sm sm:leading-6" :class="truncateText">
+                        <option v-for="dataset, datasetIdx in datasetsInSamePool" :class="truncateText" :title="dataset.name" :key="datasetIdx">{{ dataset.name }}</option>
+                    </select>
+                </div>
 
-                    <!-- New Name -->
-                    <div class="mt-2">
-                        <label :for="getIdKey('new-name')" class="mt-1 block text-sm font-medium leading-6 text-default">New Name</label>
-                        <input :id="getIdKey('new-name')" type="text" v-model="newName" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default placeholder:text-muted sm:text-sm sm:leading-6" placeholder="New Name" />
-                    </div>
+                <!-- New Name -->
+                <div class="mt-2">
+                    <label :for="getIdKey('new-name')" class="mt-1 block text-sm font-medium leading-6 text-default">New Name</label>
+                    <input :id="getIdKey('new-name')" type="text" v-model="newName" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default placeholder:text-muted sm:text-sm sm:leading-6" placeholder="New Name" />
+                </div>
 
-                    <!-- Force Unmount -->
-                    <div class="mt-2">
-                        <div class="flex flex-row justify-between">
-                            <label :for="getIdKey('force-unmount-filesystem')" class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Forcefully Unmount File System</label>
-                            <Switch v-model="forceUnmount" :id="getIdKey('force-unmount-filesystem')" :class="[forceUnmount! ? 'bg-primary' : 'bg-accent', 'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                                <span class="sr-only">Use setting</span>
-                                <span :class="[forceUnmount! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                    <span :class="[forceUnmount! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                        <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                            <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                        </svg>
-                                    </span>
-                                    <span :class="[forceUnmount! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                        <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                            <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                        </svg>
-                                    </span>
-                                </span>
-                            </Switch>
-                        </div>
+                <!-- Force Unmount -->
+                <div class="mt-2">
+                    <div class="flex flex-row justify-between">
+                        <label :for="getIdKey('force-unmount-filesystem')" class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Forcefully Unmount File System</label>
+                        <PfSwitch
+                            :modelValue="forceUnmount"
+                            @update:modelValue="forceUnmount = $event"
+                            :id="getIdKey('force-unmount-filesystem')"
+                        />
                     </div>
-                    <!-- Create non-existent parent file systems -->
-                    <div class="mt-2">
-                        <div class="flex flex-row justify-between">
-                            <label :for="getIdKey('create-parent-filesystems')" class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Create Non-Existent Parent File Systems</label>
-                            <Switch v-model="createNonExistParent" :id="getIdKey('create-parent-filesystems')" :class="[createNonExistParent! ? 'bg-primary' : 'bg-accent', 'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                                <span class="sr-only">Use setting</span>
-                                <span :class="[createNonExistParent! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                    <span :class="[createNonExistParent! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                        <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                            <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                        </svg>
-                                    </span>
-                                    <span :class="[createNonExistParent! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                        <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                            <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                        </svg>
-                                    </span>
-                                </span>
-                            </Switch>
-                        </div>
+                </div>
+                <!-- Create non-existent parent file systems -->
+                <div class="mt-2">
+                    <div class="flex flex-row justify-between">
+                        <label :for="getIdKey('create-parent-filesystems')" class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Create Non-Existent Parent File Systems</label>
+                        <PfSwitch
+                            :modelValue="createNonExistParent"
+                            @update:modelValue="createNonExistParent = $event"
+                            :id="getIdKey('create-parent-filesystems')"
+                        />
                     </div>
                 </div>
             </div>
-        </template>
-        <template v-slot:footer>
+        </div>
+
+        <template #footer>
             <div class="w-full grid grid-rows-2">
                 <div class="w-full row-start-1">
                     <p class="text-danger" v-if="nameFeedback">{{ nameFeedback }}</p>
@@ -87,13 +63,13 @@
                 </div>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 </template>
 <script setup lang="ts">
 import { ref, Ref, inject, computed } from 'vue';
 import { renameFileSystem } from '../../composables/datasets';
-import { Switch } from '@headlessui/vue';
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
+import PfSwitch from '../pf/PfSwitch.vue';
 import { ZFSFileSystemInfo } from '@45drives/houston-common-lib';
 import { pushNotification, Notification } from '@45drives/houston-common-ui';
 
@@ -144,10 +120,10 @@ const datasetsInSamePool = computed<ZFSFileSystemInfo[]>(() => {
 async function renameBtn() {
     if (nameCheck(newName.value, parentFS.value)) {
         renaming.value = true;
-        
+
         try {
 			const output: any = await renameFileSystem(props.filesystem.name, (parentFS.value + '/' + newName.value), forceUnmount.value, createNonExistParent.value);
- 
+
 			if (output == null || output.error) {
 				const errorMessage = output?.error || 'Unknown error';
 				renaming.value = false;
@@ -168,7 +144,7 @@ async function renameBtn() {
 const nameCheck = (fileSystemName, fileSystemParent) => {
     let result = true;
     nameFeedback.value = '';
-    	
+
 	if (fileSystemName == '') {
 		result = false;
 		nameFeedback.value = 'Name cannot be empty.';
@@ -197,7 +173,7 @@ function fileSystemNameExists(filesystemName, fileSystemParent, datasets : ZFSFi
 	for (const dataset of datasets) {
 		const existingParentPath = dataset.parentFS;
 		const existingDatasetName = dataset.name.split('/').pop();
-	
+
 		if (existingParentPath === newParentPath && existingDatasetName === filesystemName) {
 			return true;
 		}

--- a/zfs/src/components/file-systems/TestSSHModal.vue
+++ b/zfs/src/components/file-systems/TestSSHModal.vue
@@ -1,15 +1,11 @@
 <template>
-    <OldModal :isOpen="showFlag" @close="updateShowFlag" :marginTop="'mt-60'" :width="'w-96'" :minWidth="'min-w-min'" :closeOnBackgroundClick="false">
-        <template v-slot:title>
-            <legend class="flex justify-center">Test Passwordless SSH Connection</legend>
-        </template>
-        <template v-slot:content>
-            <label :for="getIdKey('ssh-test')" class="mt-1 block text-sm font-medium leading-6 text-default">SSH Target:</label>
-            <input @keydown.enter="" :id="getIdKey('ssh-test')" type="text" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default" name="ssh-target" v-model="sshTarget" placeholder="user@hostname or just hostname" />
-            <p v-if="result" class="text-success mt-2">{{ resultMsg }}</p>
-            <p v-if="!result" class="text-danger mt-2">{{ resultMsg }}</p>
-        </template>
-        <template v-slot:footer>
+    <PfModal :isOpen="showFlag" @close="closeModal" title="Test Passwordless SSH Connection">
+        <label :for="getIdKey('ssh-test')" class="mt-1 block text-sm font-medium leading-6 text-default">SSH Target:</label>
+        <input @keydown.enter="" :id="getIdKey('ssh-test')" type="text" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default" name="ssh-target" v-model="sshTarget" placeholder="user@hostname or just hostname" />
+        <p v-if="result" class="text-success mt-2">{{ resultMsg }}</p>
+        <p v-if="!result" class="text-danger mt-2">{{ resultMsg }}</p>
+
+        <template #footer>
             <div class="w-full grid grid-rows-1">
                 <div class="button-group-row mt-2 justify-between">
                     <button @click="closeModal" :id="getIdKey('confirm-no')" name="button-no" class="mt-1 btn btn-secondary object-left justify-start h-fit">Cancel</button>
@@ -26,11 +22,11 @@
                 </div>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 </template>
 <script setup lang="ts">
 import { ref } from 'vue';
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
 import { testSSH } from '../../composables/helpers';
 
 interface TestSSHModalProps {
@@ -42,12 +38,6 @@ const props = defineProps<TestSSHModalProps>();
 const emit = defineEmits(['close']);
 
 const showFlag = ref(props.showFlag);
-
-const updateShowFlag = () => {
-    if (props.showFlag != showFlag.value) {
-        showFlag.value = props.showFlag;
-    }
-}
 
 const closeModal = () => {
     emit('close');

--- a/zfs/src/components/snapshots/CloneSnapshot.vue
+++ b/zfs/src/components/snapshots/CloneSnapshot.vue
@@ -1,54 +1,40 @@
 <template>
-    <OldModal :isOpen="showCloneSnapModal" @close="showCloneSnapModal = false" :marginTop="'mt-28'" :width="'w-4/12'" :minWidth="'min-w-4/12'" :closeOnBackgroundClick="false">
-        <template v-slot:title>
-            <legend class="flex justify-center">Clone Snapshot</legend>
-        </template>
-        <template v-slot:content>
-            <div class="grid grid-cols-1">
-                <!-- Snapshot Name -->
-                <div class="mt-2 col-span-1">
-                    <label :for="getIdKey('snap-name')" class="mt-1 block text-sm font-medium leading-6 text-default">Snapshot Name</label>
-                    <p :class="truncateText" :title="props.snapshot.name">{{ props.snapshot.name }}</p>
-                </div>
+    <PfModal :isOpen="showCloneSnapModal" @close="showCloneSnapModal = false" title="Clone Snapshot">
+        <div class="grid grid-cols-1">
+            <!-- Snapshot Name -->
+            <div class="mt-2 col-span-1">
+                <label :for="getIdKey('snap-name')" class="mt-1 block text-sm font-medium leading-6 text-default">Snapshot Name</label>
+                <p :class="truncateText" :title="props.snapshot.name">{{ props.snapshot.name }}</p>
+            </div>
 
-                <!-- Parent File System -->
-                <div class="mt-2 col-span-1">
-                    <label :for="getIdKey('parent-filesystem')" class="block text-sm font-medium leading-6 text-default">Parent File System</label>
-                    <select v-model="parentFS" :id="getIdKey('parent-filesystem')" class="text-default bg-default mt-1 block w-full input-textlike sm:text-sm sm:leading-6">
-                        <option v-for="dataset, datasetIdx in datasetsInSamePool" :key="datasetIdx" :class="truncateText" :title="dataset.name">{{ dataset.name }}</option>
-                    </select>
-                </div>
+            <!-- Parent File System -->
+            <div class="mt-2 col-span-1">
+                <label :for="getIdKey('parent-filesystem')" class="block text-sm font-medium leading-6 text-default">Parent File System</label>
+                <select v-model="parentFS" :id="getIdKey('parent-filesystem')" class="text-default bg-default mt-1 block w-full input-textlike sm:text-sm sm:leading-6">
+                    <option v-for="dataset, datasetIdx in datasetsInSamePool" :key="datasetIdx" :class="truncateText" :title="dataset.name">{{ dataset.name }}</option>
+                </select>
+            </div>
 
-                <!-- New Name -->
-                <div class="mt-2 col-span-1">
-                    <label :for="getIdKey('new-name')" class="mt-1 block text-sm font-medium leading-6 text-default">Clone Name</label>
-                    <input :id="getIdKey('new-name')" type="text" v-model="newName" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default placeholder:text-muted sm:text-sm sm:leading-6" :placeholder="'Enter Name Here'" />
-                </div>
+            <!-- New Name -->
+            <div class="mt-2 col-span-1">
+                <label :for="getIdKey('new-name')" class="mt-1 block text-sm font-medium leading-6 text-default">Clone Name</label>
+                <input :id="getIdKey('new-name')" type="text" v-model="newName" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default placeholder:text-muted sm:text-sm sm:leading-6" :placeholder="'Enter Name Here'" />
+            </div>
 
-                <!-- Create non-existent parent file systems -->
-                <div class="mt-2 col-span-1">
-                    <div class="flex flex-row justify-between">
-                        <label :for="getIdKey('create-parent-filesystems')" class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Create Non-Existent Parent File Systems</label>
-                        <Switch v-model="createNonExistParent" :id="getIdKey('create-parent-filesystems')" :class="[createNonExistParent! ? 'bg-primary' : 'bg-accent', 'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span :class="[createNonExistParent! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span :class="[createNonExistParent! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span :class="[createNonExistParent! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
-                    </div>
+            <!-- Create non-existent parent file systems -->
+            <div class="mt-2 col-span-1">
+                <div class="flex flex-row justify-between">
+                    <label :for="getIdKey('create-parent-filesystems')" class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Create Non-Existent Parent File Systems</label>
+                    <PfSwitch
+                        :modelValue="createNonExistParent"
+                        @update:modelValue="createNonExistParent = $event"
+                        :id="getIdKey('create-parent-filesystems')"
+                    />
                 </div>
             </div>
-        </template>
-        <template v-slot:footer>
+        </div>
+
+        <template #footer>
             <div class="w-full grid grid-rows-2">
                 <div class="w-full row-start-1">
                     <p class="text-danger" v-if="nameFeedback">{{ nameFeedback }}</p>
@@ -69,13 +55,13 @@
                 </div>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 </template>
 <script setup lang="ts">
 import { ref, Ref, inject, computed } from 'vue';
 import { cloneSnapshot } from '../../composables/snapshots';
-import { Switch } from '@headlessui/vue';
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
+import PfSwitch from '../pf/PfSwitch.vue';
 import {ZFSFileSystemInfo} from "@45drives/houston-common-lib"
 import { pushNotification, Notification } from '@45drives/houston-common-ui';
 import { Snapshot } from '../../types';
@@ -130,7 +116,7 @@ async function cloneBtn() {
         cloning.value = true;
         try {
             const output: any = await cloneSnapshot(props.snapshot.name, parentFS.value, newName.value, createNonExistParent.value);
-            
+
             if (output == null || output.error) {
 				const errorMessage = output?.error || 'Unknown error';
                 pushNotification(new Notification('Snapshot Clone Failed', `There was an error cloning this snapshot: ${errorMessage}`, 'error', 5000));
@@ -156,7 +142,7 @@ async function cloneBtn() {
 const nameCheck = (fileSystemName, fileSystemParent) => {
     let result = true;
     nameFeedback.value = '';
-    	
+
 	if (fileSystemName == '') {
 		result = false;
 		nameFeedback.value = 'Name cannot be empty.';
@@ -185,7 +171,7 @@ function fileSystemNameExists(filesystemName, fileSystemParent, datasets : ZFSFi
 	for (const dataset of datasets) {
 		const existingParentPath = dataset.parentFS;
 		const existingDatasetName = dataset.name.split('/').pop();
-	
+
 		if (existingParentPath === newParentPath && existingDatasetName === filesystemName) {
 			return true;
 		}

--- a/zfs/src/components/snapshots/RenameSnapshot.vue
+++ b/zfs/src/components/snapshots/RenameSnapshot.vue
@@ -1,69 +1,45 @@
 <template>
-    <OldModal :isOpen="showRenameSnapModal" @close="showRenameSnapModal = false" :marginTop="'mt-28'" :width="'w-4/12'" :minWidth="'min-w-4/12'" :closeOnBackgroundClick="false">
-        <template v-slot:title>
-            <legend class="flex justify-center">Rename Snapshot</legend>
-        </template>
-        <template v-slot:content>
-            <div class="grid grid-cols-1">
-                <!-- Parent File System -->
-                <div class="mt-2 col-span-1">
-                    <label :for="getIdKey('parent-filesystem')" class="block text-sm font-medium leading-6 text-default">Parent File System</label>
-                    <p :class="truncateText" :title="props.snapshot.dataset">{{ props.snapshot.dataset }}</p>
-                </div>
+    <PfModal :isOpen="showRenameSnapModal" @close="showRenameSnapModal = false" title="Rename Snapshot">
+        <div class="grid grid-cols-1">
+            <!-- Parent File System -->
+            <div class="mt-2 col-span-1">
+                <label :for="getIdKey('parent-filesystem')" class="block text-sm font-medium leading-6 text-default">Parent File System</label>
+                <p :class="truncateText" :title="props.snapshot.dataset">{{ props.snapshot.dataset }}</p>
+            </div>
 
-                <!-- Set name as creation date -->
-                <div class="mt-2 col-span-1">
-                    <div class="flex flex-row justify-between">
-                        <label :for="getIdKey('set-name-creation-date')" class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Creation Date</label>
-                        <Switch v-model="creationDate" :id="getIdKey('set-name-creation-date')" :class="[creationDate! ? 'bg-primary' : 'bg-accent', 'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span :class="[creationDate! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span :class="[creationDate! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span :class="[creationDate! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
-                    </div>
-                </div>
-
-                <!-- New Name -->
-                <div class="mt-2 col-span-1">
-                    <label :for="getIdKey('new-name')" class="mt-1 block text-sm font-medium leading-6 text-default">New Name</label>
-                    <input v-if="creationDate" disabled :id="getIdKey('new-name')" type="text" v-model="newName" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default placeholder:text-muted sm:text-sm sm:leading-6" :placeholder="`${convertRawTimestampToString(props.snapshot.properties.creation.rawTimestamp)}`" />
-                    <input v-else :id="getIdKey('new-name')" type="text" v-model="newName" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default placeholder:text-muted sm:text-sm sm:leading-6" placeholder="New Name" />
-                </div>
-
-                <!-- Rename child snapshots with same name -->
-                <div class="mt-2 col-span-1">
-                    <div class="flex flex-row justify-between">
-                        <label :for="getIdKey('rename-children')" class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Rename child snapshots with same name</label>
-                        <Switch v-model="renameChildSnaps" :id="getIdKey('rename-children')" :class="[renameChildSnaps! ? 'bg-primary' : 'bg-accent', 'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-600 focus:ring-offset-2']">
-                            <span class="sr-only">Use setting</span>
-                            <span :class="[renameChildSnaps! ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-default shadow ring-0 transition duration-200 ease-in-out']">
-                                <span :class="[renameChildSnaps! ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                    <svg class="h-3 w-3 text-muted" fill="none" viewBox="0 0 12 12">
-                                        <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </span>
-                                <span :class="[renameChildSnaps! ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
-                                    <svg class="h-3 w-3 text-primary" fill="currentColor" viewBox="0 0 12 12">
-                                        <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-                                    </svg>
-                                </span>
-                            </span>
-                        </Switch>
-                    </div>
+            <!-- Set name as creation date -->
+            <div class="mt-2 col-span-1">
+                <div class="flex flex-row justify-between">
+                    <label :for="getIdKey('set-name-creation-date')" class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Creation Date</label>
+                    <PfSwitch
+                        :modelValue="creationDate"
+                        @update:modelValue="creationDate = $event"
+                        :id="getIdKey('set-name-creation-date')"
+                    />
                 </div>
             </div>
-        </template>
-        <template v-slot:footer>
+
+            <!-- New Name -->
+            <div class="mt-2 col-span-1">
+                <label :for="getIdKey('new-name')" class="mt-1 block text-sm font-medium leading-6 text-default">New Name</label>
+                <input v-if="creationDate" disabled :id="getIdKey('new-name')" type="text" v-model="newName" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default placeholder:text-muted sm:text-sm sm:leading-6" :placeholder="`${convertRawTimestampToString(props.snapshot.properties.creation.rawTimestamp)}`" />
+                <input v-else :id="getIdKey('new-name')" type="text" v-model="newName" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default placeholder:text-muted sm:text-sm sm:leading-6" placeholder="New Name" />
+            </div>
+
+            <!-- Rename child snapshots with same name -->
+            <div class="mt-2 col-span-1">
+                <div class="flex flex-row justify-between">
+                    <label :for="getIdKey('rename-children')" class="mt-2 mr-2 block text-sm font-medium leading-6 text-default">Rename child snapshots with same name</label>
+                    <PfSwitch
+                        :modelValue="renameChildSnaps"
+                        @update:modelValue="renameChildSnaps = $event"
+                        :id="getIdKey('rename-children')"
+                    />
+                </div>
+            </div>
+        </div>
+
+        <template #footer>
             <div class="w-full grid grid-rows-2">
                 <div class="w-full row-start-1">
                     <p class="text-danger" v-if="nameFeedback">{{ nameFeedback }}</p>
@@ -84,14 +60,14 @@
                 </div>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 </template>
 <script setup lang="ts">
 import { ref, Ref, inject } from 'vue';
 import { convertRawTimestampToString } from '../../composables/helpers';
 import { renameSnapshot } from '../../composables/snapshots';
-import { Switch } from '@headlessui/vue';
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
+import PfSwitch from '../pf/PfSwitch.vue';
 import {ZFSFileSystemInfo} from "../../../../houston-common/houston-common-lib/lib/managers/index"
 import { pushNotification, Notification } from '@45drives/houston-common-ui';
 import { Snapshot } from '../../types';
@@ -122,12 +98,12 @@ async function renameBtn() {
         newName.value = convertRawTimestampToString(props.snapshot.properties.creation.rawTimestamp);
     }
 
-    if (nameCheck(newName.value, parentFS.value)) {   
+    if (nameCheck(newName.value, parentFS.value)) {
         renaming.value = true;
 
         try {
 			const output: any = await renameSnapshot(props.snapshot.name, newName.value);
- 
+
 			if (output == null || output.error) {
 				const errorMessage = output?.error || 'Unknown error';
 				renaming.value = false;
@@ -175,7 +151,7 @@ const nameCheck = (snapshotName, fileSystemParent) => {
             nameFeedback.value = `Name already exists in this location: ${fileSystemParent}.`;
         }
     }
-	
+
     return result;
 }
 
@@ -184,7 +160,7 @@ function snapshotNameExists(snapshotName, fileSystemParent, datasets : ZFSFileSy
 	for (const dataset of datasets) {
 		const existingParentPath = dataset.parentFS;
 		const existingDatasetName = dataset.name.split('/').pop();
-	
+
 		if (existingParentPath === newParentPath && existingDatasetName === snapshotName) {
 			return true;
 		}

--- a/zfs/src/components/snapshots/SendSnapshot.vue
+++ b/zfs/src/components/snapshots/SendSnapshot.vue
@@ -1,82 +1,78 @@
 <template>
-    <OldModal :isOpen="showSendDataset" @close="showSendDataset = false" :marginTop="'mt-28'" :width="'w-5/12'" :minWidth="'min-w-5/12'" :closeOnBackgroundClick="false">
-        <template v-slot:title>
-            <legend class="flex justify-center">Send Dataset</legend>
-        </template>
-        <template v-slot:content>
-            <div class="grid grid-cols-2 justify-between">
-                <div class="mt-2 col-span-1">
-                    <!-- Sending Snapshot: (self) -->
-                    <label :for="getIdKey('sending-dataset-name')" class="mt-1 block text-sm font-medium leading-6 text-default">Snapshot To Send:</label>
-                    <label :id="getIdKey('sending-dataset-name')" class="mt-1 block text-sm font-base leading-6 text-default" :class="truncateText" :title="sendName">{{sendName}}</label>
+    <PfModal :isOpen="showSendDataset" @close="showSendDataset = false" title="Send Dataset" variant="large">
+        <div class="grid grid-cols-2 justify-between">
+            <div class="mt-2 col-span-1">
+                <!-- Sending Snapshot: (self) -->
+                <label :for="getIdKey('sending-dataset-name')" class="mt-1 block text-sm font-medium leading-6 text-default">Snapshot To Send:</label>
+                <label :id="getIdKey('sending-dataset-name')" class="mt-1 block text-sm font-base leading-6 text-default" :class="truncateText" :title="sendName">{{sendName}}</label>
+            </div>
+            <div class="mt-2 col-span-1 justify-self-center">
+                <button id="test-ssh" class="mt-3 btn btn-secondary h-fit" @click="showTestSSHModal()">Test Passwordless SSH</button>
+            </div>
+            <div class="mt-2 col-span-2">
+                <!-- Receiving Dataset: [User Supplied] -->
+                <label :for="getIdKey('receiving-dataset-name')" class="mt-1 block text-sm font-medium leading-6 text-default">Receiving Dataset:</label>
+                <input @keydown.enter="" @change="doesRecvDatasetExist()" :id="getIdKey('receiving-dataset-name')" type="text" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default" name="receiving-dataset-name" v-model="destinationName" placeholder="Destination Name Here" />
+                <p v-if="invalidConfig" class="mt-1 text-sm text-danger">{{ invalidConfigMsg }}</p>
+                <p v-if="invalidDest" class="mt-1 text-sm text-danger">{{ invalidDestMsg }}</p>
+                <p v-if="invalidConfig" class="mt-1 text-sm text-muted"><i>{{ mostRecentDestSnapMsg }}</i></p>
+                <p v-if="invalidConfig" class="mt-1 text-sm text-danger">{{ useForceOverwriteMsg }}</p>
+            </div>
+            <div class="mt-2 col-span-2">
+                <!-- Receiving Host: (Optional-> If Empty, then Local) -->
+                <label :for="getIdKey('receiving-host-name')" class="mt-1 block text-sm font-medium leading-6 text-default">Receiving Host:</label>
+                <input @keydown.enter="" :id="getIdKey('receiving-host-name')" type="text" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default" name="receiving-host-name" v-model="destinationHost" placeholder="(Leave empty if sending locally.)" />
+            </div>
+            <div class="mt-2 col-span-2">
+                <!-- Host User -->
+                <label :for="getIdKey('receiving-host-user')" class="mt-1 block text-sm font-medium leading-6 text-default">Receiving User:</label>
+                <input @keydown.enter="" :id="getIdKey('receiving-host-user')" type="text" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default" name="receiving-host-user" v-model="destinationHostUser" placeholder="Destination Host User" />
+            </div>
+            <div class="mt-2 col-span-2">
+                <!-- Receiving Port: [Default -> 22, User Can Change]-->
+                <label :for="getIdKey('receiving-port')" class="mt-1 block text-sm font-medium leading-6 text-default">Receiving Port:</label>
+                <input @keydown.enter="" :id="getIdKey('receiving-port')" type="text" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default" name="receiving-port" v-model="destinationPort" />
+            </div>
+            <!-- If Remote Send, have mBuffer size configurable -->
+            <div v-if="destinationHost != ''" class="mt-2 grid grid-cols-4 gap-2 col-span-2">
+                <div class="col-span-2 grid grid-cols-2 justify-items-center">
+                    <label :for="getIdKey('mbuffer-size')" class="mt-1 text-sm font-medium leading-6 text-default w-full col-span-1">mBuffer Size:</label>
+                    <input @keydown.enter="" :id="getIdKey('mbuffer-size')" type="number" class="input-textlike bg-default mt-1 w-full py-1.5 px-1.5 text-default col-span-1" name="mbuffer-size" v-model="mBufferSize" />
                 </div>
-                <div class="mt-2 col-span-1 justify-self-center">
-                    <button id="test-ssh" class="mt-3 btn btn-secondary h-fit" @click="showTestSSHModal()">Test Passwordless SSH</button>
-                </div>
-                <div class="mt-2 col-span-2">
-                    <!-- Receiving Dataset: [User Supplied] -->
-                    <label :for="getIdKey('receiving-dataset-name')" class="mt-1 block text-sm font-medium leading-6 text-default">Receiving Dataset:</label>
-                    <input @keydown.enter="" @change="doesRecvDatasetExist()" :id="getIdKey('receiving-dataset-name')" type="text" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default" name="receiving-dataset-name" v-model="destinationName" placeholder="Destination Name Here" />
-                    <p v-if="invalidConfig" class="mt-1 text-sm text-danger">{{ invalidConfigMsg }}</p>
-                    <p v-if="invalidDest" class="mt-1 text-sm text-danger">{{ invalidDestMsg }}</p>
-                    <p v-if="invalidConfig" class="mt-1 text-sm text-muted"><i>{{ mostRecentDestSnapMsg }}</i></p>
-                    <p v-if="invalidConfig" class="mt-1 text-sm text-danger">{{ useForceOverwriteMsg }}</p>
-                </div>
-                <div class="mt-2 col-span-2">
-                    <!-- Receiving Host: (Optional-> If Empty, then Local) -->
-                    <label :for="getIdKey('receiving-host-name')" class="mt-1 block text-sm font-medium leading-6 text-default">Receiving Host:</label>
-                    <input @keydown.enter="" :id="getIdKey('receiving-host-name')" type="text" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default" name="receiving-host-name" v-model="destinationHost" placeholder="(Leave empty if sending locally.)" />
-                </div>
-                <div class="mt-2 col-span-2">
-                    <!-- Host User -->
-                    <label :for="getIdKey('receiving-host-user')" class="mt-1 block text-sm font-medium leading-6 text-default">Receiving User:</label>
-                    <input @keydown.enter="" :id="getIdKey('receiving-host-user')" type="text" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default" name="receiving-host-user" v-model="destinationHostUser" placeholder="Destination Host User" />
-                </div>
-                <div class="mt-2 col-span-2">
-                    <!-- Receiving Port: [Default -> 22, User Can Change]-->
-                    <label :for="getIdKey('receiving-port')" class="mt-1 block text-sm font-medium leading-6 text-default">Receiving Port:</label>
-                    <input @keydown.enter="" :id="getIdKey('receiving-port')" type="text" class="input-textlike bg-default mt-1 block w-full py-1.5 px-1.5 text-default" name="receiving-port" v-model="destinationPort" />
-                </div>
-                <!-- If Remote Send, have mBuffer size configurable -->
-                <div v-if="destinationHost != ''" class="mt-2 grid grid-cols-4 gap-2 col-span-2">
-                    <div class="col-span-2 grid grid-cols-2 justify-items-center">
-                        <label :for="getIdKey('mbuffer-size')" class="mt-1 text-sm font-medium leading-6 text-default w-full col-span-1">mBuffer Size:</label>
-                        <input @keydown.enter="" :id="getIdKey('mbuffer-size')" type="number" class="input-textlike bg-default mt-1 w-full py-1.5 px-1.5 text-default col-span-1" name="mbuffer-size" v-model="mBufferSize" />
-                    </div>
-                    <div class="col-span-2 grid grid-cols-2 justify-items-center">
-                        <label :for="getIdKey('mbuffer-unit')" class="mt-1 text-sm font-medium leading-6 text-default w-full col-span-1">mBuffer Unit:</label>
-                        <select :id="getIdKey('mbuffer-unit')" name="mbuffer-unit" class="text-default bg-default mt-1 w-full input-textlike col-span-1" v-model="mBufferUnit">
-                            <option value="b">b</option>
-                            <option value="k">k</option>
-                            <option value="M">M</option>
-                            <option value="G">G</option>
-                        </select>
-                    </div>
-                </div>
-
-                <div class="mt-2 grid grid-flow-col col-span-2">
-                    <!-- Send Compressed: [Checkbox -> (-Lce) options] *** Cannot be used if Encrypted -->
-                    <label :for="getIdKey('send-compressed-toggle')" class="mt-1 block text-sm font-medium leading-6 text-default col-span-1">
-                        Send Compressed:
-                        <input :id="getIdKey('send-compressed-toggle')" v-model="sendCompressed" @change="handleCheckboxChange('sendCompressed')" type="checkbox" class="ml-2 w-5 h-5 text-success bg-well border-default rounded focus:ring-green-500 dark:focus:ring-green-600 dark:ring-offset-gray-800 focus:ring-2" />
-                    </label>
-                    <!-- Send Raw: [Checkbox -> (-w) option] *** If Encrypted, force this mode -->
-                    <label :for="getIdKey('send-raw-toggle')" class="mt-1 block text-sm font-medium leading-6 text-default col-span-1">
-                        Send Raw:
-                        <input :id="getIdKey('send-raw-toggle')" v-model="sendRaw" @change="handleCheckboxChange('sendRaw')" type="checkbox" class="ml-2 w-5 h-5 text-success bg-well border-default rounded focus:ring-green-500 dark:focus:ring-green-600 dark:ring-offset-gray-800 focus:ring-2" />
-                    </label>
-                    <!-- Force Overwrite: [Checkbox -> (-F) option] -->
-                    <label v-if="invalidConfig" :for="getIdKey('force-overwrite-toggle')" class="mt-1 block text-sm font-medium leading-6 text-danger col-span-1">
-                        Force Overwrite:
-                        <input :id="getIdKey('force-overwrite-toggle')" v-model="forceOverwrite" type="checkbox" class="ml-2 w-5 h-5 text-success bg-well border-default rounded focus:ring-green-500 dark:focus:ring-green-600 dark:ring-offset-gray-800 focus:ring-2" />
-                    </label>
-                </div>
-                <div class="mt-2 col-span-2">
-                    <p v-if="invalidFlags" class="mt-1 text-sm text-danger">{{ invalidFlagMsg }}</p>
+                <div class="col-span-2 grid grid-cols-2 justify-items-center">
+                    <label :for="getIdKey('mbuffer-unit')" class="mt-1 text-sm font-medium leading-6 text-default w-full col-span-1">mBuffer Unit:</label>
+                    <select :id="getIdKey('mbuffer-unit')" name="mbuffer-unit" class="text-default bg-default mt-1 w-full input-textlike col-span-1" v-model="mBufferUnit">
+                        <option value="b">b</option>
+                        <option value="k">k</option>
+                        <option value="M">M</option>
+                        <option value="G">G</option>
+                    </select>
                 </div>
             </div>
-        </template>
-        <template v-slot:footer>
+
+            <div class="mt-2 grid grid-flow-col col-span-2">
+                <!-- Send Compressed: [Checkbox -> (-Lce) options] *** Cannot be used if Encrypted -->
+                <label :for="getIdKey('send-compressed-toggle')" class="mt-1 block text-sm font-medium leading-6 text-default col-span-1">
+                    Send Compressed:
+                    <input :id="getIdKey('send-compressed-toggle')" v-model="sendCompressed" @change="handleCheckboxChange('sendCompressed')" type="checkbox" class="ml-2 w-5 h-5 text-success bg-well border-default rounded focus:ring-green-500 dark:focus:ring-green-600 dark:ring-offset-gray-800 focus:ring-2" />
+                </label>
+                <!-- Send Raw: [Checkbox -> (-w) option] *** If Encrypted, force this mode -->
+                <label :for="getIdKey('send-raw-toggle')" class="mt-1 block text-sm font-medium leading-6 text-default col-span-1">
+                    Send Raw:
+                    <input :id="getIdKey('send-raw-toggle')" v-model="sendRaw" @change="handleCheckboxChange('sendRaw')" type="checkbox" class="ml-2 w-5 h-5 text-success bg-well border-default rounded focus:ring-green-500 dark:focus:ring-green-600 dark:ring-offset-gray-800 focus:ring-2" />
+                </label>
+                <!-- Force Overwrite: [Checkbox -> (-F) option] -->
+                <label v-if="invalidConfig" :for="getIdKey('force-overwrite-toggle')" class="mt-1 block text-sm font-medium leading-6 text-danger col-span-1">
+                    Force Overwrite:
+                    <input :id="getIdKey('force-overwrite-toggle')" v-model="forceOverwrite" type="checkbox" class="ml-2 w-5 h-5 text-success bg-well border-default rounded focus:ring-green-500 dark:focus:ring-green-600 dark:ring-offset-gray-800 focus:ring-2" />
+                </label>
+            </div>
+            <div class="mt-2 col-span-2">
+                <p v-if="invalidFlags" class="mt-1 text-sm text-danger">{{ invalidFlagMsg }}</p>
+            </div>
+        </div>
+
+        <template #footer>
             <div class="button-group-row w-full row-start-2 justify-between mt-2">
                 <button id="cancel" class="mt-1 btn btn-danger object-left justify-start h-fit" @click="showSendDataset = false">Cancel</button>
 
@@ -99,7 +95,7 @@
                 </button>
             </div>
         </template>
-    </OldModal>
+    </PfModal>
 
     <div v-if="showTestSSH">
         <component :is="testSSHComponent" @close="updateShowTestSSH" :idKey="'test-ssh-modal'" :showFlag="showTestSSH" />
@@ -107,7 +103,7 @@
 
 </template>
 <script setup lang="ts">
-import OldModal from '../common/OldModal.vue';
+import PfModal from '../pf/PfModal.vue';
 import { legacy } from '@45drives/houston-common-lib';
 import { ref, Ref, inject, computed } from 'vue';
 import { sendSnapshot, doesDatasetExist, formatRecentSnaps, doesDatasetHaveSnaps } from '../../composables/snapshots';
@@ -237,7 +233,7 @@ async function doesRemoteDatasetExist() {
         return await doesDatasetExist(sendingData.value);
     } catch (error) {
         console.error('Error checking dataset', error);
-        return false; 
+        return false;
     }
 }
 
@@ -246,7 +242,7 @@ async function doesRemoteDatasetHaveSnaps() {
         return await doesDatasetHaveSnaps(sendingData.value);
     } catch (error) {
         console.error('Error checking dataset', error);
-        return false; 
+        return false;
     }
 }
 
@@ -282,7 +278,7 @@ async function setSendData() {
         } else {
             sendingData.value.recvPort = '22';
         }
-       
+
         if (sourceDataset.value!.encrypted) {
             sendRaw.value = true;
             sendCompressed.value = false;
@@ -442,7 +438,7 @@ function compareLocalTimestamp(destinationDatasetSnaps : Snapshot[], sourceDatas
                 });
                 // console.log('local sourceSnapMatch:', sourceSnapMatch.value);
                 return sourceSnapMatch.value;
-                
+
             } else if (mostRecentLocalDestSnap.value.guid == sourceSendSnap.guid) {
                 // console.log('sendSnap is the same as mostRecentDestSnap');
                 return null;
@@ -455,7 +451,7 @@ function compareLocalTimestamp(destinationDatasetSnaps : Snapshot[], sourceDatas
         console.log('no snaps to match');
         return null;
     }
-  
+
 }
 
 async function compareRemoteTimestamp(snapSnips : SnapSnippet[], sourceDatasetSnaps : Snapshot[], sourceSendSnap : Snapshot) {
@@ -477,10 +473,10 @@ async function compareRemoteTimestamp(snapSnips : SnapSnippet[], sourceDatasetSn
                 const sourceSnapMatch = computed(() => {
                     const source = sourceDatasetSnaps.find(snap => snap.guid == mostRecentRemoteDestSnap.value!.guid);
                     // console.log('source', source);
-                    return source; 
+                    return source;
                 });
                 // console.log('remote sourceSnapMatch:', sourceSnapMatch.value);
-                
+
                 if (sourceSnapMatch.value == undefined) {
                     return null;
                 } else {
@@ -585,7 +581,7 @@ async function readSendProgress(sendProgressData : SendProgress[], fileReader: I
     try {
         let initialRun = true;
         let nullRun = true;
-       
+
         function fillProgressArray(content, sendProgressData : SendProgress[]) {
             if (initialRun && nullRun) {
                 initialRun = false;
@@ -602,7 +598,7 @@ async function readSendProgress(sendProgressData : SendProgress[], fileReader: I
                     sendProgressAmount.value = getSendProgress(content.sent)!;
                     // console.log(`content.totalSize: ${content.totalSize}, content.sent: ${content.sent}`);
                     // console.log(`totalSendSize: ${totalSendSize.value}, sendProgAmount: ${sendProgressAmount.value}`);
-                }    
+                }
             }
         }
 
@@ -637,7 +633,7 @@ async function sendAndReadProgress(sendingData : SendingDataset, sendProgress : 
     } catch (error) {
         console.error("An error occurred in sendAndReadProgress:", error);
         // return null;
-        
+
         // return false;
     }
 }

--- a/zfs/src/components/snapshots/SnapshotsList.vue
+++ b/zfs/src/components/snapshots/SnapshotsList.vue
@@ -2,184 +2,138 @@
 	<div class="TableDiv">
 		<!-- POOLS -->
 		<div v-if="props.item == 'pool'"
-			class="inline-block min-w-full max-h-96 align-middle border border-default border-collapse overflow-y-auto">
-			<table class="table-auto min-w-full min-h-full divide-y divide-default ">
-				<thead class="bg-well border-collapse">
-					<tr v-if="snapshots.length > 0 && !snapshotsInPoolLoading"
-						class="rounded-md grid grid-cols-7 font-semibold text-white">
-						<th class="py-2 col-span-2 text-center" :class="truncateText" title="Snapshot">Snapshot</th>
-						<th class="py-2 col-span-1 text-center" :class="truncateText" title="Created On">Created On</th>
-						<th class="py-2 col-span-1 text-center" :class="truncateText" title="Used">Used</th>
-						<th class="py-2 col-span-1 text-center" :class="truncateText" title="Referenced">Referenced</th>
-						<th class="py-2 col-span-1 text-center" :class="truncateText" title="Clones">Clones</th>
-						<th class="relative py-2 sm:pr-6 lg:pr-8 rounded-tr-md col-span-1">
-							<span class="sr-only"></span>
+			class="inline-block min-w-full align-middle border border-default border-collapse">
+			<table v-if="snapshots.length > 0 && !snapshotsInPoolLoading"
+				class="pf-v5-c-table pf-m-compact" role="grid">
+				<thead>
+					<tr role="row">
+						<th class="pf-v5-c-table__th" role="columnheader" scope="col">Snapshot</th>
+						<th class="pf-v5-c-table__th" role="columnheader" scope="col">Created On</th>
+						<th class="pf-v5-c-table__th" role="columnheader" scope="col">Used</th>
+						<th class="pf-v5-c-table__th" role="columnheader" scope="col">Referenced</th>
+						<th class="pf-v5-c-table__th" role="columnheader" scope="col">Clones</th>
+						<th class="pf-v5-c-table__th pf-v5-c-table__action" role="columnheader" scope="col">
+							<span class="sr-only">Actions</span>
 						</th>
 					</tr>
-					<tr v-if="snapshots.length < 1 && !snapshotsInPoolLoading"
-						class="grid grid-cols-1 items-center justify-center w-full">
-						<p class="bg-accent text-default text-center py-2 justify-self-center w-full">No snapshots
-							found.</p>
-					</tr>
-					<tr v-if="snapshotsInPoolLoading"
-						class="rounded-md flex bg-well justify-center justify-self-center w-full">
-						<LoadingSpinner :width="'w-10'" :height="'h-10'" :baseColor="'text-gray-200'"
-							:fillColor="'fill-slate-500'" />
-					</tr>
 				</thead>
-				<tbody class="divide-y divide-default bg-default border-collapse">
-					<tr v-if="snapshots.length > 0 && !snapshotsInPoolLoading"
-						v-for="snapshot, snapshotIdx in snapshots" :key="snapshotIdx"
-						class="text-default grid grid-cols-7 justify-center items-center">
-						<td class="py-1 px-3 text-sm font-medium text-default text-left col-span-2"
-							:class="truncateText" :title="snapshot.name">
+				<tbody role="rowgroup">
+					<tr v-for="(snapshot, snapshotIdx) in snapshots" :key="snapshotIdx"
+						class="pf-v5-c-table__tr" role="row">
+						<td class="pf-v5-c-table__td" role="cell"
+							:data-label="'Snapshot'" :class="truncateText" :title="snapshot.name">
 							{{ snapshot.name }}
 						</td>
-						<td class="py-1 px-3 text-sm text-default text-center col-span-1" :class="truncateText"
-							:title="snapshot.properties.creation.parsed">
+						<td class="pf-v5-c-table__td" role="cell"
+							:data-label="'Created On'" :class="truncateText" :title="snapshot.properties.creation.parsed">
 							{{ snapshot.properties.creation.parsed }}
 						</td>
-						<td class="py-1 px-3 text-sm text-default text-center col-span-1" :class="truncateText"
-							:title="snapshot.properties.used.value">
+						<td class="pf-v5-c-table__td" role="cell"
+							:data-label="'Used'" :class="truncateText" :title="snapshot.properties.used.value">
 							{{ snapshot.properties.used.value }}
 						</td>
-						<td class="py-1 px-3 text-sm text-default text-center col-span-1" :class="truncateText"
-							:title="snapshot.properties.referenced.value">
+						<td class="pf-v5-c-table__td" role="cell"
+							:data-label="'Referenced'" :class="truncateText" :title="snapshot.properties.referenced.value">
 							{{ snapshot.properties.referenced.value }}
 						</td>
-						<td class="py-1 px-3 text-sm text-default text-center col-span-1" :class="truncateText"
-							:title="snapshot.properties.clones">
+						<td class="pf-v5-c-table__td" role="cell"
+							:data-label="'Clones'" :class="truncateText" :title="snapshot.properties.clones">
 							{{ snapshot.properties.clones.length > 0 ? snapshot.properties.clones : '-' }}
 						</td>
-						<td
-							class="relative py-1 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 lg:pr-8 col-span-1 justify-self-end">
-							<Menu as="div" class="relative inline-block text-right">
-								<div>
-									<MenuButton
-										class="flex items-center rounded-full bg-default p-2 text-default hover:text-default focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 focus:ring-offset-gray-100">
-										<span class="sr-only">Open options</span>
-										<EllipsisVerticalIcon class="w-5" aria-hidden="true" />
-									</MenuButton>
-								</div>
-
-								<transition enter-active-class="transition ease-out duration-100"
-									enter-from-class="transform opacity-0 scale-95"
-									enter-to-class="transform opacity-100 scale-100"
-									leave-active-class="transition ease-in duration-75"
-									leave-from-class="transform opacity-100 scale-100"
-									leave-to-class="transform opacity-0 scale-95">
-									<MenuItems @click.stop
-										class="absolute right-0 z-10 mt-2 w-max origin-top-left rounded-md bg-accent shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-										<div class="py-1">
-											<!-- <MenuItem as="div" v-slot="{ active }" >
-												<a href="#" @click="cloneThisSnapshot(snapshot)" :class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Clone Snapshot</a>
-											</MenuItem> -->
-											<MenuItem as="div" v-slot="{ active }">
-											<a href="#" @click="renameThisSnapshot(snapshot)"
-												:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Rename
-												Snapshot</a>
-											</MenuItem>
-											<MenuItem as="div" v-slot="{ active }">
-											<a href="#" @click="rollbackThisSnapshot(snapshot)"
-												:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Roll
-												Back Snapshot</a>
-											</MenuItem>
-											<!-- <MenuItem as="div" v-slot="{ active }" >
-												<a href="#" @click="sendThisDataset(snapshot)" :class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Send Snapshot</a>
-											</MenuItem> -->
-											<MenuItem as="div" v-slot="{ active }">
-											<a href="#" @click="destroyThisSnapshot(snapshot)"
-												:class="[active ? 'bg-danger text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Destroy
-												Snapshot</a>
-											</MenuItem>
-										</div>
-									</MenuItems>
-								</transition>
-							</Menu>
+						<td class="pf-v5-c-table__td pf-v5-c-table__action" role="cell">
+							<PfDropdownMenu
+								:items="getPoolSnapshotActions(snapshot)"
+								:kebab="true"
+							/>
 						</td>
 					</tr>
 				</tbody>
 			</table>
+			<div v-if="snapshots.length < 1 && !snapshotsInPoolLoading"
+				class="pf-v5-c-empty-state pf-m-sm">
+				<div class="pf-v5-c-empty-state__content">
+					<h2 class="pf-v5-c-empty-state__header pf-v5-c-title pf-m-lg">No snapshots found.</h2>
+				</div>
+			</div>
+			<div v-if="snapshotsInPoolLoading"
+				class="flex bg-well justify-center w-full p-4">
+				<LoadingSpinner :width="'w-10'" :height="'h-10'" :baseColor="'text-gray-200'"
+					:fillColor="'fill-slate-500'" />
+			</div>
 		</div>
 
 		<!-- FILESYSTEMS -->
-		<div v-if="props.item == 'filesystem'" class="inline-block min-w-full max-h-3/4 align-middle border-collapse"
-			:class="{ 'overflow-y-scroll': snapshotsInFilesystem.length > 15 }">
-			<table v-if="!snapshotsInDatasetLoaded && !snapshotNotFound"
-				class="table-auto min-w-full min-h-full divide-y divide-default">
-				<tr class="rounded-md flex bg-well justify-center">
-					<LoadingSpinner :width="'w-10'" :height="'h-10'" :baseColor="'text-gray-200'"
-						:fillColor="'fill-slate-500'" />
-				</tr>
-			</table>
+		<div v-if="props.item == 'filesystem'" class="inline-block min-w-full align-middle border-collapse">
+			<div v-if="!snapshotsInDatasetLoaded && !snapshotNotFound"
+				class="flex bg-well justify-center w-full p-4">
+				<LoadingSpinner :width="'w-10'" :height="'h-10'" :baseColor="'text-gray-200'"
+					:fillColor="'fill-slate-500'" />
+			</div>
 			<table v-if="snapshotsInFilesystem.length > 0 && snapshotsInDatasetLoaded"
-				class="table-auto min-w-full min-h-full divide-y divide-default">
-				<thead class="bg-secondary border-collapse">
-					<tr class="rounded-md grid grid-cols-8 font-semibold text-white">
-						<th class="py-2 col-span-2 text-center" :class="truncateText" title="Snapshot">Snapshot</th>
-						<th class="py-2 col-span-1 text-center" :class="truncateText" title="Created On">Created On</th>
-						<th class="py-2 col-span-1 text-center" :class="truncateText" title="Used">Used</th>
-						<th class="py-2 col-span-1 text-center" :class="truncateText" title="Referenced">Referenced</th>
-						<th v-if="!bulkSnapDestroyMode.get(props.filesystem!.name)" class="py-2 col-span-2 text-center"
-							:class="truncateText" title="Clones">Clones</th>
-						<th v-if="bulkSnapDestroyMode.get(props.filesystem!.name)" class="py-2 col-span-1 text-center"
-							:class="truncateText" title="Clones">Clones</th>
-						<th v-if="bulkSnapDestroyMode.get(props.filesystem!.name)" class="py-2 col-span-1 text-center"
-							:class="truncateText" title="Select">Select</th>
-						<th v-if="bulkSnapDestroyMode.get(props.filesystem!.name)"
-							class="py-2 col-span-1 text-center flex flex-col">
-							<label class="flex flex-row items-center w-full h-full rounded-lg"
-								:class="checkboxSelectedAllClass">
-								<input type="checkbox" v-model="isSelectAllChecked" @change="toggleSelectAll"
-									class="w-4 h-4 mr-2 text-success border-default rounded focus:ring-green-500 dark:focus:ring-green-600 focus:ring-2" />
-								Select All
-							</label>
-							<button v-if="bulkSnapDestroyMode.get(props.filesystem!.name) && canDestructive"
-								:disabled="selectedForDestroy.length == 0 || operationRunning"
-								@click="destroySelectedSnapshots()" name="destroy-multiple-snaps-btn"
-								class="btn btn-danger h-min w-full text-xs">
-								<span v-if="!operationRunning">Destroy Selected</span>
-								<span v-else>
-									Destroying {{ bulkDestroyProcessed }} / {{ bulkDestroyTotal }} snapshots...
-								</span>
-							</button>
+				class="pf-v5-c-table pf-m-compact" role="grid">
+				<thead>
+					<tr role="row">
+						<th class="pf-v5-c-table__th" role="columnheader" scope="col">Snapshot</th>
+						<th class="pf-v5-c-table__th" role="columnheader" scope="col">Created On</th>
+						<th class="pf-v5-c-table__th" role="columnheader" scope="col">Used</th>
+						<th class="pf-v5-c-table__th" role="columnheader" scope="col">Referenced</th>
+						<th class="pf-v5-c-table__th" role="columnheader" scope="col">Clones</th>
+						<th v-if="bulkSnapDestroyMode.get(props.filesystem!.name)" class="pf-v5-c-table__th" role="columnheader" scope="col">Select</th>
+						<th v-if="bulkSnapDestroyMode.get(props.filesystem!.name)" class="pf-v5-c-table__th" role="columnheader" scope="col">
+							<div class="flex flex-col">
+								<label class="flex flex-row items-center w-full h-full rounded-lg"
+									:class="checkboxSelectedAllClass">
+									<input type="checkbox" v-model="isSelectAllChecked" @change="toggleSelectAll"
+										class="w-4 h-4 mr-2 text-success border-default rounded focus:ring-green-500 dark:focus:ring-green-600 focus:ring-2" />
+									Select All
+								</label>
+								<button v-if="bulkSnapDestroyMode.get(props.filesystem!.name) && canDestructive"
+									:disabled="selectedForDestroy.length == 0 || operationRunning"
+									@click="destroySelectedSnapshots()" name="destroy-multiple-snaps-btn"
+									class="btn btn-danger h-min w-full text-xs">
+									<span v-if="!operationRunning">Destroy Selected</span>
+									<span v-else>
+										Destroying {{ bulkDestroyProcessed }} / {{ bulkDestroyTotal }} snapshots...
+									</span>
+								</button>
+							</div>
 						</th>
-						<th v-else class="relative py-2 sm:pr-6 lg:pr-8 rounded-tr-md col-span-1">
-							<span class="sr-only"></span>
+						<th v-if="!bulkSnapDestroyMode.get(props.filesystem!.name)" class="pf-v5-c-table__th pf-v5-c-table__action" role="columnheader" scope="col">
+							<span class="sr-only">Actions</span>
 						</th>
 					</tr>
 				</thead>
-				<tbody class="divide-y divide-default bg-accent border-collapse">
-					<tr v-for="snapshot, snapshotIdx in snapshotsInFilesystem" :key="snapshotIdx"
-						class="text-default grid grid-cols-8 justify-center items-center">
-						<td class="py-1 px-3 text-sm font-medium text-default text-left col-span-2"
-							:class="truncateText" :title="snapshot.name">
+				<tbody role="rowgroup">
+					<tr v-for="(snapshot, snapshotIdx) in snapshotsInFilesystem" :key="snapshotIdx"
+						class="pf-v5-c-table__tr" role="row">
+						<td class="pf-v5-c-table__td" role="cell"
+							:data-label="'Snapshot'" :class="truncateText" :title="snapshot.name">
 							{{ snapshot.name }}
 						</td>
-						<td class="py-1 px-3 text-sm text-default text-center col-span-1" :class="truncateText"
-							:title="snapshot.properties.creation.parsed">
+						<td class="pf-v5-c-table__td" role="cell"
+							:data-label="'Created On'" :class="truncateText" :title="snapshot.properties.creation.parsed">
 							{{ snapshot.properties.creation.parsed }}
 						</td>
-						<td class="py-1 px-3 text-sm text-default text-center col-span-1" :class="truncateText"
-							:title="snapshot.properties.used.value">
+						<td class="pf-v5-c-table__td" role="cell"
+							:data-label="'Used'" :class="truncateText" :title="snapshot.properties.used.value">
 							{{ snapshot.properties.used.value }}
 						</td>
-						<td class="py-1 px-3 text-sm text-default text-center col-span-1" :class="truncateText"
-							:title="snapshot.properties.referenced.value">
+						<td class="pf-v5-c-table__td" role="cell"
+							:data-label="'Referenced'" :class="truncateText" :title="snapshot.properties.referenced.value">
 							{{ snapshot.properties.referenced.value }}
 						</td>
 						<td v-if="!bulkSnapDestroyMode.get(props.filesystem!.name)"
-							class="py-1 px-3 text-sm text-default text-center col-span-2" :class="truncateText"
-							:title="snapshot.properties.clones">
+							class="pf-v5-c-table__td" role="cell"
+							:data-label="'Clones'" :class="truncateText" :title="snapshot.properties.clones">
 							{{ snapshot.properties.clones.length > 0 ? snapshot.properties.clones : '-' }}
 						</td>
 						<td v-if="bulkSnapDestroyMode.get(props.filesystem!.name)"
-							class="py-1 px-3 text-sm text-default text-center col-span-1" :class="truncateText"
-							:title="snapshot.properties.clones">
+							class="pf-v5-c-table__td" role="cell"
+							:data-label="'Clones'" :class="truncateText" :title="snapshot.properties.clones">
 							{{ snapshot.properties.clones.length > 0 ? snapshot.properties.clones : '-' }}
 						</td>
 						<td v-if="bulkSnapDestroyMode.get(props.filesystem!.name)"
-							class="text-sm text-default text-center col-span-1 p-0">
+							class="pf-v5-c-table__td" role="cell">
 							<label
 								class="flex justify-center items-center w-full h-full py-2 rounded-lg border border-default bg-well"
 								:class="checkboxSelectedClass(snapshot.name)">
@@ -187,59 +141,12 @@
 									class="w-4 h-4 text-success border-default rounded focus:ring-green-500 dark:focus:ring-green-600 focus:ring-2" />
 							</label>
 						</td>
-						<td
-							class="relative py-1 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 lg:pr-8 col-span-1 justify-self-end">
-							<Menu as="div" class="relative inline-block text-right">
-								<div>
-									<MenuButton @click.stop :disabled="!canDestructive" :aria-disabled="!canDestructive"
-										:title="!canDestructive ? 'Requires administrative privileges' : ''" :class="[
-											'flex items-center rounded-full p-2 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 focus:ring-offset-gray-100',
-											canDestructive ? 'bg-accent hover:text-white cursor-pointer'
-												: 'bg-accent/60 text-muted cursor-not-allowed'
-										]">
-										<span class="sr-only">Open options</span>
-										<EllipsisVerticalIcon class="w-5" aria-hidden="true" />
-									</MenuButton>
-								</div>
-
-								<transition enter-active-class="transition ease-out duration-100"
-									enter-from-class="transform opacity-0 scale-95"
-									enter-to-class="transform opacity-100 scale-100"
-									leave-active-class="transition ease-in duration-75"
-									leave-from-class="transform opacity-100 scale-100"
-									leave-to-class="transform opacity-0 scale-95">
-									<MenuItems
-										class="absolute right-0 z-10 mt-2 w-max origin-top-left rounded-md bg-accent shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-										<div class="py-1">
-											<MenuItem as="div" v-slot="{ active }">
-											<a href="#" @click="cloneThisSnapshot(snapshot)"
-												:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Clone
-												Snapshot</a>
-											</MenuItem>
-											<MenuItem as="div" v-slot="{ active }">
-											<a href="#" @click="renameThisSnapshot(snapshot)"
-												:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Rename
-												Snapshot</a>
-											</MenuItem>
-											<MenuItem as="div" v-slot="{ active }">
-											<a href="#" @click="rollbackThisSnapshot(snapshot)"
-												:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Roll
-												Back Snapshot</a>
-											</MenuItem>
-											<MenuItem as="div" v-slot="{ active }">
-											<a href="#" @click="sendThisDataset(snapshot)"
-												:class="[active ? 'bg-default text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Send
-												Snapshot</a>
-											</MenuItem>
-											<MenuItem as="div" v-slot="{ active }">
-											<a href="#" @click="destroyThisSnapshot(snapshot)"
-												:class="[active ? 'bg-danger text-default' : 'text-muted', 'block px-4 py-2 text-sm']">Destroy
-												Snapshot</a>
-											</MenuItem>
-										</div>
-									</MenuItems>
-								</transition>
-							</Menu>
+						<td v-if="!bulkSnapDestroyMode.get(props.filesystem!.name)"
+							class="pf-v5-c-table__td pf-v5-c-table__action" role="cell">
+							<PfDropdownMenu
+								:items="getFilesystemSnapshotActions(snapshot)"
+								:kebab="true"
+							/>
 						</td>
 					</tr>
 				</tbody>
@@ -252,8 +159,11 @@
 					Destroying {{ bulkDestroyProcessed }} / {{ bulkDestroyTotal }} snapshots...
 				</span>
 			</button>
-			<div v-if="snapshotsInFilesystem.length === 0 && snapshotNotFound" class="text-center bg-well">
-				<p>No snapshots found.</p>
+			<div v-if="snapshotsInFilesystem.length === 0 && snapshotNotFound"
+				class="pf-v5-c-empty-state pf-m-sm">
+				<div class="pf-v5-c-empty-state__content">
+					<h2 class="pf-v5-c-empty-state__header pf-v5-c-title pf-m-lg">No snapshots found.</h2>
+				</div>
 			</div>
 		</div>
 
@@ -299,11 +209,11 @@
 </template>
 <script setup lang="ts">
 import { ref, inject, Ref, provide, watch, onMounted } from 'vue';
-import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue';
-import { EllipsisVerticalIcon } from '@heroicons/vue/24/outline';
 import { loadSnapshotsInPool, loadSnapshotsInDataset } from '../../composables/loadData';
 import { destroySnapshot, rollbackSnapshot } from '../../composables/snapshots';
 import LoadingSpinner from '../common/LoadingSpinner.vue';
+import PfDropdownMenu from '../pf/PfDropdownMenu.vue';
+import type { DropdownMenuItem } from '../pf/PfDropdownMenu.vue';
 import { ZPool,ZFSFileSystemInfo} from "@45drives/houston-common-lib"
 import { pushNotification, Notification } from '@45drives/houston-common-ui';
 import { Snapshot, ConfirmationCallback } from '../../types';
@@ -319,6 +229,25 @@ interface SnapshotsListProps {
 const props = defineProps<SnapshotsListProps>();
 const truncateText = inject<Ref<string>>('style-truncate-text')!;
 const canDestructive = inject<Ref<boolean>>('can-destructive')!;
+
+function getPoolSnapshotActions(snapshot: Snapshot): DropdownMenuItem[] {
+	return [
+		{ label: 'Rename Snapshot', action: () => renameThisSnapshot(snapshot) },
+		{ label: 'Roll Back Snapshot', action: () => rollbackThisSnapshot(snapshot) },
+		{ label: 'Destroy Snapshot', action: () => destroyThisSnapshot(snapshot) },
+	];
+}
+
+function getFilesystemSnapshotActions(snapshot: Snapshot): DropdownMenuItem[] {
+	return [
+		{ label: 'Clone Snapshot', action: () => cloneThisSnapshot(snapshot), disabled: !canDestructive.value, tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined },
+		{ label: 'Rename Snapshot', action: () => renameThisSnapshot(snapshot), disabled: !canDestructive.value, tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined },
+		{ label: 'Roll Back Snapshot', action: () => rollbackThisSnapshot(snapshot), disabled: !canDestructive.value, tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined },
+		{ label: 'Send Snapshot', action: () => sendThisDataset(snapshot), disabled: !canDestructive.value, tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined },
+		{ label: 'Destroy Snapshot', action: () => destroyThisSnapshot(snapshot), disabled: !canDestructive.value, tooltip: !canDestructive.value ? 'Requires administrative privileges' : undefined },
+	];
+}
+
 ////////////////// Loading Data /////////////////////
 /////////////////////////////////////////////////////
 const snapshotsInPoolLoading = ref(false);
@@ -345,7 +274,7 @@ onMounted(async () => {
         } else if (props.item === 'filesystem') {
 			snapshotsInFilesystem.value = [];
             await loadSnapshotsInDataset(snapshotsInFilesystem, props.filesystem!.name,snapshotNotFound,snapshotsInDatasetLoaded);
-			
+
         } else if (props.item == 'singleSnap') {
 		selectedSnapshot.value = snapshots.value.find(snapshot => snapshot.name == props.singleSnap!.name);
 	}
@@ -383,7 +312,7 @@ async function destroyThisSnapshot(snapshot) {
 	// console.log("snapshot: ", snapshot)
 	operationRunning.value = false;
 	selectedSnapshot.value = snapshot;
-	
+
 	if (selectedSnapshot.value!.properties.clones.length > 0) {
 		hasChildren.value = true;
 	}


### PR DESCRIPTION
## Summary

- FileSystemList: PF semantic table, expandable rows, PfDropdownMenu
- SnapshotsList: PF semantic table, PfDropdownMenu, remove nested scroll, PF EmptyState
- Migrate 8 modals from OldModal → PfModal
- Replace all HeadlessUI Switch → PfSwitch
- Remove all @headlessui/vue imports
- Net -224 lines

Closes #51

## Test plan

- [ ] File Systems tab renders
- [ ] Dataset rows expandable
- [ ] Snapshot list renders without nested scroll
- [ ] All modals open/close correctly
- [ ] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)